### PR TITLE
Add header parsers for safetensors, ONNX, and GGUF

### DIFF
--- a/headers.py
+++ b/headers.py
@@ -1,0 +1,122 @@
+"""Model header readers for various artifact formats.
+
+This module exposes tiny utilities to introspect model files without
+materialising the full weights.  Each reader returns a :class:`Meta`
+object describing tensor names/shapes and any useful scalar hints
+(e.g. vocab size, context length).
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+import json
+
+
+@dataclass
+class TensorInfo:
+    """Lightweight description of a tensor."""
+
+    name: str
+    shape: Tuple[int, ...]
+
+
+@dataclass
+class Meta:
+    """Summary of a model's tensors and scalar hints."""
+
+    tensors: List[TensorInfo]
+    hints: Dict[str, Any] = field(default_factory=dict)
+
+
+def _ensure_path(path: Path | str) -> Path:
+    if isinstance(path, Path):
+        return path
+    return Path(path)
+
+
+def read_safetensors_header(path: Path | str) -> Meta:
+    """Read the header of a ``.safetensors`` file.
+
+    Only the JSON header is parsed; tensor data is never materialised.
+    Any top-level ``metadata`` section is returned verbatim as hints.
+    """
+    p = _ensure_path(path)
+    with p.open("rb") as f:
+        header_len = int.from_bytes(f.read(8), "little")
+        header = json.loads(f.read(header_len).decode("utf-8"))
+
+    hints = header.get("__metadata__", {}) if isinstance(header, dict) else {}
+    tensors = [
+        TensorInfo(name=name, shape=tuple(int(d) for d in info["shape"]))
+        for name, info in header.items()
+        if name != "__metadata__"
+    ]
+    return Meta(tensors=tensors, hints=dict(hints))
+
+
+def read_onnx_header(path: Path | str) -> Meta:
+    """Read tensor names and shapes from an ONNX file.
+
+    The graph initialisers are inspected to build the tensor list.  A
+    heuristic attempts to recover the vocabulary size from any
+    embedding matrix.
+    """
+    import onnx
+
+    p = _ensure_path(path)
+    model = onnx.load(p, load_external_data=False)
+
+    tensors = [
+        TensorInfo(name=init.name, shape=tuple(int(d) for d in init.dims))
+        for init in model.graph.initializer
+    ]
+
+    hints: Dict[str, Any] = {}
+    for init in model.graph.initializer:
+        name_l = init.name.lower()
+        if len(init.dims) == 2 and any(k in name_l for k in ("embed", "vocab")):
+            hints["vocab_size"] = int(init.dims[0])
+            break
+
+    return Meta(tensors=tensors, hints=hints)
+
+
+def read_gguf_header(path: Path | str) -> Meta:
+    """Read tensor names, shapes and common metadata from a GGUF file."""
+    import gguf
+
+    p = _ensure_path(path)
+    reader = gguf.GGUFReader(p)
+
+    tensors = [
+        TensorInfo(name=t.name, shape=tuple(int(s) for s in t.shape))
+        for t in reader.tensors
+    ]
+
+    hints: Dict[str, Any] = {}
+    arch_field = reader.get_field("general.architecture")
+    arch = arch_field.contents() if arch_field else None
+    if arch:
+        key_map = {
+            "vocab_size": gguf.KEY_VOCAB_SIZE.format(arch=arch),
+            "context_length": gguf.KEY_CONTEXT_LENGTH.format(arch=arch),
+            "rope_dimension_count": gguf.KEY_ROPE_DIMENSION_COUNT.format(arch=arch),
+            "rope_freq_base": gguf.KEY_ROPE_FREQ_BASE.format(arch=arch),
+            "rope_scale": gguf.KEY_ROPE_SCALING_FACTOR.format(arch=arch),
+        }
+        for hint_key, field_key in key_map.items():
+            field = reader.get_field(field_key)
+            if field is not None:
+                hints[hint_key] = field.contents()
+
+    return Meta(tensors=tensors, hints=hints)
+
+
+__all__ = [
+    "TensorInfo",
+    "Meta",
+    "read_safetensors_header",
+    "read_onnx_header",
+    "read_gguf_header",
+]


### PR DESCRIPTION
## Summary
- add `headers` module with `TensorInfo`, `Meta`, and readers for safetensors, ONNX, and GGUF artifacts
- extract tensor shapes and common hints like vocab size or context length

## Testing
- `python - <<'PY'
from headers import read_safetensors_header, read_onnx_header, read_gguf_header
import numpy as np, tempfile, os, onnx, gguf
from safetensors.numpy import save_file
from onnx import helper, TensorProto

# safetensors
fn_s=tempfile.NamedTemporaryFile(delete=False).name
save_file({'w': np.zeros((2,3))}, fn_s, metadata={'vocab_size':'5'})
meta_s = read_safetensors_header(fn_s)
print('safetensors', meta_s.tensors[0].name, meta_s.tensors[0].shape, meta_s.hints)
os.unlink(fn_s)

# onnx
weights = np.zeros((7,4), dtype=np.float32)
init = helper.make_tensor(name='word_embedding', data_type=TensorProto.FLOAT, dims=weights.shape, vals=weights.flatten())
graph = helper.make_graph([], 'g', [], [], [init])
model = helper.make_model(graph)
fn_o=tempfile.NamedTemporaryFile(delete=False).name
onnx.save(model, fn_o)
meta_o = read_onnx_header(fn_o)
print('onnx', meta_o.tensors[0].name, meta_o.tensors[0].shape, meta_o.hints)
os.unlink(fn_o)

# gguf
fn_g=tempfile.NamedTemporaryFile(delete=False).name
w=gguf.GGUFWriter(fn_g, arch='test')
w.add_tensor('t', np.zeros((1,), dtype=np.float32))
w.add_uint32(gguf.KEY_VOCAB_SIZE.format(arch='test'), 9)
w.add_uint32(gguf.KEY_CONTEXT_LENGTH.format(arch='test'), 16)
w.write_header_to_file(); w.write_kv_data_to_file(); w.write_tensors_to_file(); w.close()
meta_g = read_gguf_header(fn_g)
print('gguf', meta_g.tensors[0].name, meta_g.tensors[0].shape, meta_g.hints)
os.unlink(fn_g)
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a7df701e18832c8c4ceda8d397a103