### PR TITLE
Add planning and puppet utilities

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -1,0 +1,78 @@
+"""Candidate planner merging seed hypotheses with default spaces.
+
+This module exposes a tiny planning helper used by the probing loop.  Given
+an initial set of hypotheses (e.g. ``{"TEXT_EMB_d": 2048}``) it returns an
+ordered candidate space where seeded values are prioritised but the default
+space is preserved for back-off.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from itertools import product
+from typing import Any, Dict, Iterator, Mapping, Sequence
+
+DEFAULT_CANDIDATES: Dict[str, Sequence[Any]] = {
+    "TEXT_EMB_d": [768, 1024, 1280, 1536, 2048, 4096],
+    "HEAD": ["epsilon", "v", "flow"],
+    "LATENT_C": [4, 8],
+    "LATENT_SCALE": [8, 16],
+    "VISION": ["ViT-L/14-grid", "ViT-H/14-grid", "SigLIP-H-map"],
+}
+
+ORDER = ["TEXT_EMB_d", "HEAD", "LATENT_C", "LATENT_SCALE", "VISION"]
+
+
+def plan_candidates(
+    seed: Mapping[str, Any],
+    defaults: Mapping[str, Sequence[Any]] | None = None,
+) -> Dict[str, list[Any]]:
+    """Merge ``seed`` with ``defaults`` to build candidate lists.
+
+    Seeded values appear first in the list for their key.  Unknown keys in
+    ``seed`` are carried through unchanged.
+    """
+    defaults = dict(defaults or DEFAULT_CANDIDATES)
+    result: Dict[str, list[Any]] = {}
+    for key, vals in defaults.items():
+        if key in seed:
+            val = seed[key]
+            result[key] = [val, *(v for v in vals if v != val)]
+        else:
+            result[key] = list(vals)
+    for key, val in seed.items():
+        if key not in result:
+            result[key] = [val]
+    return result
+
+
+@dataclass
+class Planner:
+    """Iterate through probe candidate combinations.
+
+    The enumeration order favours collapsing large uncertainties first:
+    ``TEXT_EMB_d → HEAD → LATENT_C → LATENT_SCALE → VISION``.
+    """
+
+    seed: Mapping[str, Any] = field(default_factory=dict)
+    defaults: Mapping[str, Sequence[Any]] = field(
+        default_factory=lambda: DEFAULT_CANDIDATES
+    )
+    order: Sequence[str] = field(default_factory=lambda: ORDER)
+
+    def __post_init__(self) -> None:
+        self.candidates = plan_candidates(self.seed, self.defaults)
+        keys = [k for k in self.order if k in self.candidates]
+        self._keys = keys
+        self._iter: Iterator[tuple[Any, ...]] = product(
+            *(self.candidates[k] for k in keys)
+        )
+
+    def __iter__(self) -> "Planner":  # pragma: no cover - trivial
+        return self
+
+    def __next__(self) -> Dict[str, Any]:
+        values = next(self._iter)
+        return dict(zip(self._keys, values))
+
+
+__all__ = ["DEFAULT_CANDIDATES", "plan_candidates", "Planner"]

--- a/puppets.py
+++ b/puppets.py
@@ -1,0 +1,54 @@
+"""Sock-puppet tensor emitters used by the probing loop.
+
+These helpers generate tiny tensors with the correct geometry for various
+model inputs.  They guarantee shapes but not semantics.
+"""
+from __future__ import annotations
+
+from typing import Tuple
+import numpy as np
+
+try:  # optional dependency
+    import torch
+    _HAS_TORCH = True
+except Exception:  # pragma: no cover - fallback
+    torch = None
+    _HAS_TORCH = False
+
+__all__ = ["text_emb", "latent", "vision_grid", "kv_cache_probe"]
+
+
+def _randn(shape: Tuple[int, ...]):
+    if _HAS_TORCH:
+        return torch.randn(shape)
+    return np.random.randn(*shape).astype(np.float32)
+
+
+def text_emb(d: int):
+    """Dummy text embedding ``[1, 2, d]``."""
+    return _randn((1, 2, int(d)))
+
+
+def latent(c: int, scale: int, base_hw: int = 64):
+    """Dummy latent ``[1, C, H/scale, W/scale]`` for base ``64×64`` images."""
+    h = w = base_hw // int(scale)
+    return _randn((1, int(c), h, w))
+
+
+def vision_grid(profile: str):
+    """Dummy image tensor for common vision backbones."""
+    shapes = {
+        "ViT-L/14-grid": (1, 3, 224, 224),
+        "ViT-H/14-grid": (1, 3, 224, 224),
+        "SigLIP-H-map": (1, 3, 256, 256),
+    }
+    shape = shapes.get(profile)
+    if shape is None:
+        raise KeyError(f"unknown vision profile: {profile}")
+    return _randn(shape)
+
+
+def kv_cache_probe(n_heads: int, d_head: int, t: int = 2):
+    """Dummy key/value cache tensor for LLM probes."""
+    shape = (2, int(n_heads), t, int(d_head))
+    return _randn(shape)


### PR DESCRIPTION
## Summary
- add candidate planner merging seed guesses with default spaces
- provide sock-puppet tensor utilities for text embeddings, latents and more

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7e06c9550832c92c3e9cfbcd51888