### PR TITLE
Add printers helpers and proof transcript output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Run the skeleton CLI:
 python reshell.py --artifact path/to/model.safetensors --out out_dir
 ```
 
-The command prints placeholder locations for `contact_trace.json` and `obligations.json`.
+The command prints placeholder locations for `contact_trace.json`, `obligations.json`, and `proof.txt`.

--- a/printers.py
+++ b/printers.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+"""Utility renderers for probe outputs.
+
+This module collects small helpers that render the results of a probing
+run into either JSON-serialisable structures or human-friendly CLI
+strings.  The functions are intentionally tiny and do not attempt to be
+complete – they merely provide placeholders for richer implementations.
+"""
+
+from typing import Any, Dict, Iterable, List
+
+
+# Mapping from hypothesis keys to obligation templates.  Each template is
+# rendered with a placeholder when the corresponding hypothesis is
+# missing.
+_OBLIGATION_TEMPLATES = {
+    "TEXT_EMB_d": "TEXT_ENCODER(dim={})",
+    "LATENT_C": "VAE(C={})",
+    "LATENT_SCALE": "VAE(scale={})",
+    "HEAD": "UNET(head={})",
+    "VISION": "VISION_ADAPTER(profile={})",
+}
+
+
+def contact_trace(hyp: Dict[str, Any], validation: Dict[str, Any] | None = None, fmt: str = "json") -> Any:
+    """Render a minimal contact trace.
+
+    Parameters
+    ----------
+    hyp:
+        Dictionary of resolved hypotheses.
+    validation:
+        Optional extra artefacts gathered during validation.
+    fmt:
+        Output format – ``"json"`` yields a dict suitable for
+        ``json.dumps`` while ``"cli"`` returns a simple string for
+        terminal display.
+    """
+
+    data = {"hypotheses": hyp}
+    if validation:
+        data["validation"] = validation
+
+    if fmt == "json":
+        return data
+    if fmt == "cli":
+        parts: List[str] = []
+        if "TEXT_EMB_d" in hyp:
+            parts.append(f"TEXT_EMB[d={hyp['TEXT_EMB_d']}]")
+        if "HEAD" in hyp:
+            parts.append(f"UNET(head={hyp['HEAD']})")
+        if "LATENT_C" in hyp and "LATENT_SCALE" in hyp:
+            parts.append(f"VAE(C={hyp['LATENT_C']},scale={hyp['LATENT_SCALE']})")
+        if "VISION" in hyp:
+            parts.append(f"VISION(profile={hyp['VISION']})")
+        return " -> ".join(parts) or "<empty>"
+    raise ValueError(f"unknown format: {fmt}")
+
+
+def obligations(hyp: Dict[str, Any], fmt: str = "json") -> Any:
+    """Derive outstanding component obligations from hypotheses.
+
+    Missing hypothesis keys are rendered into user-readable obligation
+    messages.
+    """
+
+    missing = [template.format("?") for key, template in _OBLIGATION_TEMPLATES.items() if key not in hyp]
+
+    if fmt == "json":
+        return missing
+    if fmt == "cli":
+        return "\n".join(f"* {m}" for m in missing)
+    raise ValueError(f"unknown format: {fmt}")
+
+
+def proof(log: Iterable[str], fmt: str = "cli") -> Any:
+    """Render the proof transcript.
+
+    ``log`` is expected to be an iterable of already-formatted lines.  By
+    default a single CLI string is returned; ``fmt="json"`` yields a
+    list of lines suitable for serialising.
+    """
+
+    if fmt == "json":
+        return list(log)
+    if fmt == "cli":
+        return "\n".join(log)
+    raise ValueError(f"unknown format: {fmt}")

--- a/reshell.py
+++ b/reshell.py
@@ -15,6 +15,7 @@ from typing import Any, Dict, Tuple
 
 from headers import Meta, read_gguf_header, read_onnx_header, read_safetensors_header
 from planner import Planner
+from printers import contact_trace, obligations, proof
 from puppets import latent, text_emb, vision_grid
 from sandbox import spawn_sandbox
 
@@ -39,7 +40,7 @@ def _dummy_engine_forward(artifact: Path, inputs: Dict[str, Any]) -> str:
     return "ok"
 
 
-def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path]:
+def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path, Path]:
     """Run a tiny probing loop over candidate combinations."""
 
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -49,7 +50,7 @@ def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path]:
     planner = Planner(seed=hypotheses)
     sandbox = spawn_sandbox({"timeout": 2.0})
 
-    results: list[Dict[str, Any]] = []
+    proof_log: list[str] = []
     for combo in planner:
         puppet_inputs: Dict[str, Any] = {}
         if "TEXT_EMB_d" in combo:
@@ -62,18 +63,23 @@ def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path]:
         try:
             sandbox.try_forward(_dummy_engine_forward, artifact, puppet_inputs)
             hypotheses.update(combo)
-            results.append({"candidate": combo, "status": "ok"})
+            proof_log.append(f"candidate {combo} -> ok")
             break
         except Exception as e:  # pragma: no cover - error path
-            results.append({"candidate": combo, "status": "error", "reason": str(e)})
+            proof_log.append(f"candidate {combo} -> error: {e}")
 
-    contact_trace = out_dir / "contact_trace.json"
-    obligations = out_dir / "obligations.json"
-    contact_trace.write_text(json.dumps({"hypotheses": hypotheses, "results": results}))
-    pending = {k: v for k, v in planner.candidates.items() if k not in hypotheses}
-    obligations.write_text(json.dumps(pending))
+    trace_json = contact_trace(hypotheses, fmt="json")
+    oblig_json = obligations(hypotheses, fmt="json")
+    proof_text = proof(proof_log, fmt="cli")
 
-    return contact_trace, obligations
+    contact_trace_path = out_dir / "contact_trace.json"
+    obligations_path = out_dir / "obligations.json"
+    proof_path = out_dir / "proof.txt"
+    contact_trace_path.write_text(json.dumps(trace_json))
+    obligations_path.write_text(json.dumps(oblig_json))
+    proof_path.write_text(proof_text)
+
+    return contact_trace_path, obligations_path, proof_path
 
 
 def main(artifact: str, out_dir: str = "out") -> None:
@@ -87,9 +93,10 @@ def main(artifact: str, out_dir: str = "out") -> None:
         Directory where probe results should be written.  The directory
         is created if it does not exist.
     """
-    contact_trace, obligations = run_pipeline(Path(artifact), Path(out_dir))
+    contact_trace, obligations, proof_file = run_pipeline(Path(artifact), Path(out_dir))
     print(f"contact trace written to: {contact_trace}")
     print(f"obligations written to: {obligations}")
+    print(f"proof transcript written to: {proof_file}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `printers` module with helpers for contact trace, obligations, and proof rendering
- update CLI pipeline to emit `contact_trace.json`, `obligations.json`, and `proof.txt`
- document new proof transcript output in README

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7e1c87110832c92a83341cbb093e9