### PR TITLE
Add pyproject and console script for reshell CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,20 @@
 
 * **Docs:** see [docs/RESHELL.md](docs/RESHELL.md) for foundation libraries, MVP sprint plan, vision, and project summary.
 
-## Usage
+## Installation
 
-Run the skeleton CLI:
+Install the package and its command-line interface with:
 
 ```bash
-python reshell.py --artifact path/to/model.safetensors --out out_dir
+pip install .
+```
+
+## Usage
+
+After installation the `reshell` command becomes available:
+
+```bash
+reshell --artifact path/to/model.safetensors --out out_dir
 ```
 
 The command prints placeholder locations for `contact_trace.json`, `obligations.json`, and `proof.txt`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "reshell"
+version = "0.1.0"
+description = "Tiny probing CLI for model artifacts"
+readme = "README.md"
+requires-python = ">=3.8"
+license = { file = "LICENSE" }
+authors = [{name = "Aumlit Contributors"}]
+dependencies = [
+    "onnx",
+    "gguf",
+]
+
+[project.scripts]
+reshell = "reshell:main"
+
+[tool.setuptools]
+py-modules = ["reshell", "headers", "printers", "planner", "puppets", "sandbox"]

--- a/reshell.py
+++ b/reshell.py
@@ -82,8 +82,8 @@ def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path, Path]:
     return contact_trace_path, obligations_path, proof_path
 
 
-def main(artifact: str, out_dir: str = "out") -> None:
-    """Parse arguments and delegate to the probing pipeline.
+def _run(artifact: str, out_dir: str = "out") -> None:
+    """Delegate to the probing pipeline.
 
     Parameters
     ----------
@@ -99,10 +99,15 @@ def main(artifact: str, out_dir: str = "out") -> None:
     print(f"proof transcript written to: {proof_file}")
 
 
-if __name__ == "__main__":
+def main() -> None:
+    """Entry-point for the console script."""
     parser = argparse.ArgumentParser(description="Probe a model artifact")
     parser.add_argument("--artifact", required=True, help="path to model artifact")
     parser.add_argument("--out", default="out", help="output directory for results")
     args = parser.parse_args()
 
-    main(args.artifact, args.out)
+    _run(args.artifact, args.out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add pyproject.toml with setuptools backend, dependencies, and reshell console script
- expose `reshell` entry point that parses CLI args
- document installation and CLI usage in README

## Testing
- `pip install --force-reinstall .`
- `reshell --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7e59c7148832c9e64a6c059a02174