### PR TITLE
Add PyInstaller build and release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,45 @@
+name: build-release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install . pyinstaller
+      - name: Build binary
+        run: |
+          pyinstaller --onefile --name reshell reshell.py
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: reshell-${{ matrix.os }}
+          path: dist/*
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: dist
+      - name: Create release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/**/reshell*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+dist/
+*.spec

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: build build-linux build-macos build-windows clean
+
+build: build-linux
+
+build-linux:
+	pyinstaller --onefile --name reshell reshell.py
+
+build-macos:
+	pyinstaller --onefile --name reshell reshell.py
+
+build-windows:
+	pyinstaller --onefile --name reshell.exe reshell.py
+
+clean:
+	rm -rf build dist reshell.spec

--- a/README.md
+++ b/README.md
@@ -24,3 +24,23 @@ reshell --artifact path/to/model.safetensors --out out_dir
 ```
 
 The command prints placeholder locations for `contact_trace.json`, `obligations.json`, and `proof.txt`.
+
+## Building standalone binaries
+
+Standalone binaries can be produced with [PyInstaller](https://pyinstaller.org/).
+
+On Linux and macOS:
+
+```bash
+make build
+```
+
+On Windows:
+
+```powershell
+.\build.ps1
+```
+
+The resulting executable is written to the `dist/` directory.
+
+Prebuilt binaries for common platforms are published with each GitHub release.

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,1 @@
+pyinstaller --onefile --name reshell.exe reshell.py


### PR DESCRIPTION
## Summary
- add Makefile and Windows script to build standalone `reshell` binaries with PyInstaller
- document how to build binaries and where to download releases
- build and publish binaries for Linux, macOS, and Windows via GitHub Actions
- ignore build artifacts

## Testing
- `make build`
- `pytest` (no tests run)


------
https://chatgpt.com/codex/tasks/task_e_68a81fd05250832c8aa1ebf70c457dcc