### PR TITLE
Add regex error classification and golden tests

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -1,0 +1,40 @@
+"""Regex-based error classifier extracting hypothesis hints."""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict
+
+# Map hypothesis keys to regex patterns capturing the relevant value.
+# Patterns are intentionally broad and numeric groups are prioritised.
+ERROR_PATTERNS = {
+    "TEXT_EMB_d": r"COND_DIM[:\s]+(?:expected\s+)?(\d+)",
+    "LATENT_C": r"LATENT_C[:\s]+(?:expected\s+)?(\d+)",
+    "HEAD": r"HEAD[:\s]+(?:expected\s+)?(epsilon|v|flow)",
+    "LATENT_SCALE": r"LATENT_SCALE[:\s]+(?:expected\s+)?(\d+)",
+    # VISION adapter failures often surface the profile name
+    "VISION": r"VISION_ADAPTER[:\s]+([A-Za-z0-9\-_/]+)",
+    # LLM-specific hints
+    "KV_DTYPE": r"KV(?:_CACHE)?_DTYPE[:=\s]+([A-Za-z0-9_]+)",
+    "VOCAB": r"VOCAB[=:\s]+(\d+)",
+    "ROPE": r"ROPE[=:\s]+(\d+)(k)?",
+}
+
+
+def parse_reason(msg: str) -> Dict[str, Any]:
+    """Extract hypothesis updates from ``msg`` using regex rules."""
+    if "'" in msg:
+        msg = msg.split("'", 2)[1]
+    for key, pattern in ERROR_PATTERNS.items():
+        m = re.search(pattern, msg, re.IGNORECASE)
+        if not m:
+            continue
+        val: Any = m.group(1)
+        if key in {"TEXT_EMB_d", "LATENT_C", "LATENT_SCALE", "VOCAB", "ROPE"}:
+            val = int(val)
+            if key == "ROPE" and m.group(2):
+                val *= 1000
+        return {key: val}
+    return {}
+
+
+__all__ = ["parse_reason", "ERROR_PATTERNS"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,19 @@ authors = [{name = "Aumlit Contributors"}]
 dependencies = [
     "onnx",
     "gguf",
+    "PyYAML",
 ]
 
 [project.scripts]
 reshell = "reshell:main"
 
 [tool.setuptools]
-py-modules = ["reshell", "headers", "printers", "planner", "puppets", "sandbox"]
+py-modules = [
+    "classifier",
+    "reshell",
+    "headers",
+    "printers",
+    "planner",
+    "puppets",
+    "sandbox",
+]

--- a/reshell.py
+++ b/reshell.py
@@ -13,6 +13,8 @@ import json
 from pathlib import Path
 from typing import Any, Dict, Tuple
 
+from classifier import parse_reason
+
 from headers import Meta, read_gguf_header, read_onnx_header, read_safetensors_header
 from planner import Planner
 from printers import contact_trace, obligations, proof
@@ -157,20 +159,6 @@ def _probe_engine_forward(artifact: Path, inputs: Dict[str, Any]) -> str:
     return _torch_engine_forward(artifact, inputs)
 
 
-def _parse_reason(msg: str) -> Dict[str, Any]:
-    """Extract hypothesis updates from ``msg`` if possible."""
-    # Errors may be wrapped like ``RuntimeError('COND_DIM: expected 4')`` –
-    # peel off the wrapper if present.
-    if "'" in msg:
-        msg = msg.split("'", 2)[1]
-    parts = msg.split()
-    if msg.startswith("COND_DIM") and parts[-1].isdigit():
-        return {"TEXT_EMB_d": int(parts[-1])}
-    if msg.startswith("LATENT_C") and parts[-1].isdigit():
-        return {"LATENT_C": int(parts[-1])}
-    return {}
-
-
 def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path, Path]:
     """Run a tiny probing loop over candidate combinations."""
 
@@ -198,7 +186,7 @@ def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path, Path]:
             break
         except Exception as e:  # pragma: no cover - error path
             reason = str(e)
-            updates = _parse_reason(reason)
+            updates = parse_reason(reason)
             if updates:
                 hypotheses.update(updates)
             proof_log.append(f"candidate {combo} -> {reason}")

--- a/rules/error_rules.yaml
+++ b/rules/error_rules.yaml
@@ -1,0 +1,16 @@
+- msg: "COND_DIM: expected 2048"
+  update: {TEXT_EMB_d: 2048}
+- msg: "LATENT_C: expected 4"
+  update: {LATENT_C: 4}
+- msg: "HEAD: expected v"
+  update: {HEAD: v}
+- msg: "LATENT_SCALE: expected 16"
+  update: {LATENT_SCALE: 16}
+- msg: "VISION_ADAPTER: ViT-L/14-grid"
+  update: {VISION: ViT-L/14-grid}
+- msg: "KV_DTYPE: f16"
+  update: {KV_DTYPE: f16}
+- msg: "VOCAB: 32000"
+  update: {VOCAB: 32000}
+- msg: "ROPE: 128k"
+  update: {ROPE: 128000}

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import sys
+import yaml
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from classifier import parse_reason
+
+
+def test_error_rules():
+    rules_path = Path(__file__).parent.parent / "rules" / "error_rules.yaml"
+    cases = yaml.safe_load(rules_path.read_text())
+    for case in cases:
+        msg = case["msg"]
+        expected = case["update"]
+        assert parse_reason(msg) == expected


### PR DESCRIPTION
## Summary
- factor parsing logic into new `classifier` module with regex rules for HEAD, LATENT_SCALE, VISION_ADAPTER, KV, VOCAB, and ROPE hints
- wire classifier into `reshell` and include PyYAML dependency
- add golden error-rule yaml and tests verifying parsing of synthetic errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a82649452c832cae89541d89adf500