### PR TITLE
Support dynamic planner pruning and metadata seeding

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -74,5 +74,25 @@ class Planner:
         values = next(self._iter)
         return dict(zip(self._keys, values))
 
+    def update(self, hyp: Mapping[str, Any]) -> None:
+        """Prune candidate lists according to ``hyp`` and reset iteration.
+
+        Any key present in ``hyp`` is fixed to its provided value.  If the
+        value differs from the current candidate space the internal iterator is
+        rebuilt so subsequent ``next`` calls reflect the new hypothesis state.
+        """
+
+        changed = False
+        for key, val in hyp.items():
+            current = self.candidates.get(key)
+            if current == [val]:
+                continue
+            self.candidates[key] = [val]
+            changed = True
+        if changed:
+            keys = [k for k in self.order if k in self.candidates]
+            self._keys = keys
+            self._iter = product(*(self.candidates[k] for k in keys))
+
 
 __all__ = ["DEFAULT_CANDIDATES", "plan_candidates", "Planner"]

--- a/reshell.py
+++ b/reshell.py
@@ -165,7 +165,7 @@ def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path, Path]:
     out_dir.mkdir(parents=True, exist_ok=True)
     meta = _read_meta(artifact)
 
-    hypotheses: Dict[str, Any] = {}
+    hypotheses: Dict[str, Any] = dict(meta.hints)
     planner = Planner(seed=hypotheses)
     sandbox = spawn_sandbox({"timeout": 2.0})
 
@@ -189,6 +189,7 @@ def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path, Path]:
             updates = parse_reason(reason)
             if updates:
                 hypotheses.update(updates)
+                planner.update(hypotheses)
             proof_log.append(f"candidate {combo} -> {reason}")
 
     trace_json = contact_trace(hypotheses, fmt="json")

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from planner import Planner
+
+
+def test_planner_update_prunes_and_resets():
+    p = Planner(seed={})
+    next(p)  # consume the first combination (TEXT_EMB_d=768)
+    p.update({"TEXT_EMB_d": 4096})
+    combo = next(p)
+    assert combo["TEXT_EMB_d"] == 4096
+    assert p.candidates["TEXT_EMB_d"] == [4096]

--- a/tests/test_reshell.py
+++ b/tests/test_reshell.py
@@ -36,5 +36,5 @@ def test_run_pipeline_failure_classification(tmp_path):
     trace = json.loads(ct_path.read_text())
     assert trace["hypotheses"]["TEXT_EMB_d"] == 4
     proof = proof_path.read_text()
-    assert "COND_DIM" in proof
+    assert "COND_DIM" in proof and "ok" in proof
     assert oblig_path.read_text()


### PR DESCRIPTION
## Summary
- add `Planner.update` to prune candidates when hypotheses tighten
- seed initial planner with metadata hints and refresh after failures
- expand tests for planner updating and pipeline behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a827765034832cbdb0fd1575760dac