### PR TITLE
Collect validation metrics after probe

### DIFF
--- a/printers.py
+++ b/printers.py
@@ -54,7 +54,16 @@ def contact_trace(hyp: Dict[str, Any], validation: Dict[str, Any] | None = None,
             parts.append(f"VAE(C={hyp['LATENT_C']},scale={hyp['LATENT_SCALE']})")
         if "VISION" in hyp:
             parts.append(f"VISION(profile={hyp['VISION']})")
-        return " -> ".join(parts) or "<empty>"
+        trace = " -> ".join(parts) or "<empty>"
+        if validation:
+            metrics: List[str] = []
+            if "time_ms" in validation:
+                metrics.append(f"{validation['time_ms']:.1f}ms")
+            if "vram_mb" in validation:
+                metrics.append(f"{validation['vram_mb']:.1f}MB")
+            if metrics:
+                trace = f"{trace} ({', '.join(metrics)})"
+        return trace
     raise ValueError(f"unknown format: {fmt}")
 
 
@@ -74,7 +83,7 @@ def obligations(hyp: Dict[str, Any], fmt: str = "json") -> Any:
     raise ValueError(f"unknown format: {fmt}")
 
 
-def proof(log: Iterable[str], fmt: str = "cli") -> Any:
+def proof(log: Iterable[str], validation: Dict[str, Any] | None = None, fmt: str = "cli") -> Any:
     """Render the proof transcript.
 
     ``log`` is expected to be an iterable of already-formatted lines.  By
@@ -82,8 +91,11 @@ def proof(log: Iterable[str], fmt: str = "cli") -> Any:
     list of lines suitable for serialising.
     """
 
+    lines = list(log)
+    if validation:
+        lines.append(f"validate {validation}")
     if fmt == "json":
-        return list(log)
+        return lines
     if fmt == "cli":
-        return "\n".join(log)
+        return "\n".join(lines)
     raise ValueError(f"unknown format: {fmt}")

--- a/reshell.py
+++ b/reshell.py
@@ -170,6 +170,7 @@ def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path, Path]:
     sandbox = spawn_sandbox({"timeout": 2.0})
 
     proof_log: list[str] = []
+    validation: Dict[str, Any] | None = None
     for combo in planner:
         puppet_inputs: Dict[str, Any] = {}
         if "TEXT_EMB_d" in combo:
@@ -183,6 +184,7 @@ def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path, Path]:
             sandbox.try_forward(_probe_engine_forward, artifact, puppet_inputs)
             hypotheses.update(combo)
             proof_log.append(f"candidate {combo} -> ok")
+            validation = sandbox.validate_min_run(_probe_engine_forward, artifact, puppet_inputs)
             break
         except Exception as e:  # pragma: no cover - error path
             reason = str(e)
@@ -192,9 +194,9 @@ def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path, Path]:
                 planner.update(hypotheses)
             proof_log.append(f"candidate {combo} -> {reason}")
 
-    trace_json = contact_trace(hypotheses, fmt="json")
+    trace_json = contact_trace(hypotheses, validation, fmt="json")
     oblig_json = obligations(hypotheses, fmt="json")
-    proof_text = proof(proof_log, fmt="cli")
+    proof_text = proof(proof_log, validation, fmt="cli")
 
     contact_trace_path = out_dir / "contact_trace.json"
     obligations_path = out_dir / "obligations.json"

--- a/sandbox.py
+++ b/sandbox.py
@@ -77,6 +77,58 @@ class Sandbox:
             return payload
         raise RuntimeError(payload)
 
+    def validate_min_run(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Mapping[str, float]:
+        """Run ``fn`` once more to collect timing and VRAM metrics."""
+
+        q: Queue = Queue()
+
+        def worker(q: Queue) -> None:
+            if self.limits.cpu_mem:
+                try:
+                    resource.setrlimit(resource.RLIMIT_AS, (self.limits.cpu_mem, self.limits.cpu_mem))
+                except Exception:  # pragma: no cover - platform may lack rlimit
+                    pass
+            if self.limits.vram:
+                mb = self.limits.vram // (1024 * 1024)
+                os.environ["PYTORCH_CUDA_ALLOC_CONF"] = f"max_split_size_mb:{mb}"
+
+            import time
+            start = time.perf_counter()
+            try:
+                import torch
+                if torch.cuda.is_available():  # pragma: no cover - depends on torch
+                    torch.cuda.reset_peak_memory_stats()
+            except Exception:  # pragma: no cover - optional dependency
+                pass
+
+            try:
+                fn(*args, **kwargs)
+                duration = (time.perf_counter() - start) * 1000.0
+                vram = 0.0
+                try:
+                    import torch
+                    if torch.cuda.is_available():  # pragma: no cover - depends on torch
+                        vram = torch.cuda.max_memory_allocated() / (1024 * 1024)
+                except Exception:  # pragma: no cover - optional dependency
+                    pass
+                q.put(("ok", {"time_ms": duration, "vram_mb": vram}))
+            except Exception as e:  # pragma: no cover - error path
+                q.put(("err", repr(e)))
+
+        p = Process(target=worker, args=(q,))
+        p.start()
+        p.join(self.limits.timeout)
+        if p.is_alive():
+            p.terminate()
+            p.join()
+            raise TimeoutError("sandbox timed out")
+        if q.empty():
+            raise RuntimeError("sandbox produced no result")
+        status, payload = q.get()
+        if status == "ok":
+            return payload
+        raise RuntimeError(payload)
+
 
 # Factory -----------------------------------------------------------
 def spawn_sandbox(limits: Mapping[str, int | float] | None = None) -> Sandbox:


### PR DESCRIPTION
## Summary
- add `Sandbox.validate_min_run` to capture timing and VRAM usage
- record validation data in probe pipeline and include it in trace and proof outputs
- show validation metrics in CLI and JSON renderers

## Testing
- `pytest tests/test_classifier.py -q`
- `pytest tests/test_reshell.py -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68a828df9050832cb8671f9fe5552aca