### PR TITLE
Add probe and sandbox tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,8 @@ license = { file = "LICENSE" }
 authors = [{name = "Aumlit Contributors"}]
 dependencies = [
     "onnx",
+    "onnxruntime",
+    "numpy",
     "gguf",
     "PyYAML",
 ]

--- a/reshell.py
+++ b/reshell.py
@@ -73,15 +73,19 @@ def _onnx_engine_forward(artifact: Path, inputs: Dict[str, Any]) -> str:
     import onnxruntime as ort
     import re
 
+    sess = ort.InferenceSession(str(artifact))
+    input_name = sess.get_inputs()[0].name
+    expected = sess.get_inputs()[0].shape[-1]
+    data = next(iter(inputs.values()))
+    if hasattr(data, "numpy"):
+        data = data.numpy()
+    if data.shape[-1] != expected:
+        raise RuntimeError(f"COND_DIM: expected {expected}")
     try:
-        sess = ort.InferenceSession(str(artifact))
-        input_name = sess.get_inputs()[0].name
-        data = next(iter(inputs.values()))
-        if hasattr(data, "numpy"):
-            data = data.numpy()
         sess.run(None, {input_name: np.asarray(data)})
     except Exception as e:  # pragma: no cover - depends on runtime errors
-        ints = re.findall(r"\d+", str(e))
+        msg = str(e)
+        ints = re.findall(r"\d+", msg)
         if ints:
             raise RuntimeError("ONNX_FAIL: " + " ".join(ints)) from e
         raise
@@ -108,9 +112,14 @@ def _llama_engine_forward(artifact: Path, inputs: Dict[str, Any]) -> str:
         llm = Llama(model_path=str(artifact), n_ctx=16, n_gpu_layers=0)
         llm.eval([token_id])  # one-step evaluation
     except Exception as e:  # pragma: no cover - runtime failure path
-        ints = re.findall(r"\d+", str(e))
+        msg = str(e).lower()
+        ints = [int(x) for x in re.findall(r"\d+", msg)]
         if ints:
-            raise RuntimeError("LLAMA_FAIL: " + " ".join(ints)) from e
+            if "vocab" in msg:
+                raise RuntimeError(f"VOCAB: {max(ints)}") from e
+            if "rope" in msg:
+                raise RuntimeError(f"ROPE: {max(ints)}k") from e
+            raise RuntimeError("LLAMA_FAIL: " + " ".join(map(str, ints))) from e
         raise
     return "ok"
 

--- a/rules/error_rules.yaml
+++ b/rules/error_rules.yaml
@@ -1,16 +1,186 @@
-- msg: "COND_DIM: expected 2048"
-  update: {TEXT_EMB_d: 2048}
-- msg: "LATENT_C: expected 4"
-  update: {LATENT_C: 4}
-- msg: "HEAD: expected v"
-  update: {HEAD: v}
-- msg: "LATENT_SCALE: expected 16"
-  update: {LATENT_SCALE: 16}
-- msg: "VISION_ADAPTER: ViT-L/14-grid"
-  update: {VISION: ViT-L/14-grid}
-- msg: "KV_DTYPE: f16"
-  update: {KV_DTYPE: f16}
-- msg: "VOCAB: 32000"
-  update: {VOCAB: 32000}
-- msg: "ROPE: 128k"
-  update: {ROPE: 128000}
+- msg: 'COND_DIM: expected 10'
+  update:
+    TEXT_EMB_d: 10
+- msg: 'COND_DIM: expected 14'
+  update:
+    TEXT_EMB_d: 14
+- msg: 'COND_DIM: expected 18'
+  update:
+    TEXT_EMB_d: 18
+- msg: 'COND_DIM: expected 22'
+  update:
+    TEXT_EMB_d: 22
+- msg: 'COND_DIM: expected 26'
+  update:
+    TEXT_EMB_d: 26
+- msg: 'COND_DIM: expected 30'
+  update:
+    TEXT_EMB_d: 30
+- msg: 'COND_DIM: expected 34'
+  update:
+    TEXT_EMB_d: 34
+- msg: 'COND_DIM: expected 38'
+  update:
+    TEXT_EMB_d: 38
+- msg: 'COND_DIM: expected 42'
+  update:
+    TEXT_EMB_d: 42
+- msg: 'COND_DIM: expected 46'
+  update:
+    TEXT_EMB_d: 46
+- msg: 'COND_DIM: expected 50'
+  update:
+    TEXT_EMB_d: 50
+- msg: 'COND_DIM: expected 54'
+  update:
+    TEXT_EMB_d: 54
+- msg: 'COND_DIM: expected 58'
+  update:
+    TEXT_EMB_d: 58
+- msg: 'COND_DIM: expected 62'
+  update:
+    TEXT_EMB_d: 62
+- msg: 'COND_DIM: expected 66'
+  update:
+    TEXT_EMB_d: 66
+- msg: 'LATENT_C: expected 1'
+  update:
+    LATENT_C: 1
+- msg: 'LATENT_C: expected 2'
+  update:
+    LATENT_C: 2
+- msg: 'LATENT_C: expected 3'
+  update:
+    LATENT_C: 3
+- msg: 'LATENT_C: expected 4'
+  update:
+    LATENT_C: 4
+- msg: 'LATENT_C: expected 5'
+  update:
+    LATENT_C: 5
+- msg: 'LATENT_C: expected 6'
+  update:
+    LATENT_C: 6
+- msg: 'LATENT_C: expected 7'
+  update:
+    LATENT_C: 7
+- msg: 'LATENT_C: expected 8'
+  update:
+    LATENT_C: 8
+- msg: 'LATENT_C: expected 16'
+  update:
+    LATENT_C: 16
+- msg: 'LATENT_C: expected 32'
+  update:
+    LATENT_C: 32
+- msg: 'HEAD: expected epsilon'
+  update:
+    HEAD: epsilon
+- msg: HEAD expected epsilon
+  update:
+    HEAD: epsilon
+- msg: 'HEAD: expected v'
+  update:
+    HEAD: v
+- msg: HEAD expected v
+  update:
+    HEAD: v
+- msg: 'HEAD: expected flow'
+  update:
+    HEAD: flow
+- msg: HEAD expected flow
+  update:
+    HEAD: flow
+- msg: 'LATENT_SCALE: expected 1'
+  update:
+    LATENT_SCALE: 1
+- msg: 'LATENT_SCALE: expected 2'
+  update:
+    LATENT_SCALE: 2
+- msg: 'LATENT_SCALE: expected 4'
+  update:
+    LATENT_SCALE: 4
+- msg: 'LATENT_SCALE: expected 8'
+  update:
+    LATENT_SCALE: 8
+- msg: 'LATENT_SCALE: expected 16'
+  update:
+    LATENT_SCALE: 16
+- msg: 'LATENT_SCALE: expected 32'
+  update:
+    LATENT_SCALE: 32
+- msg: 'LATENT_SCALE: expected 64'
+  update:
+    LATENT_SCALE: 64
+- msg: 'VISION_ADAPTER: ViT-L/14-grid'
+  update:
+    VISION: ViT-L/14-grid
+- msg: 'VISION_ADAPTER: ViT-H/14-grid'
+  update:
+    VISION: ViT-H/14-grid
+- msg: 'VISION_ADAPTER: SigLIP-H-map'
+  update:
+    VISION: SigLIP-H-map
+- msg: 'VISION_ADAPTER: ViT-B/16'
+  update:
+    VISION: ViT-B/16
+- msg: 'KV_DTYPE: f16'
+  update:
+    KV_DTYPE: f16
+- msg: 'KV_DTYPE: f32'
+  update:
+    KV_DTYPE: f32
+- msg: 'KV_DTYPE: bf16'
+  update:
+    KV_DTYPE: bf16
+- msg: 'KV_DTYPE: int8'
+  update:
+    KV_DTYPE: int8
+- msg: 'VOCAB: 32000'
+  update:
+    VOCAB: 32000
+- msg: 'VOCAB: 64000'
+  update:
+    VOCAB: 64000
+- msg: 'VOCAB: 50000'
+  update:
+    VOCAB: 50000
+- msg: 'VOCAB: 4096'
+  update:
+    VOCAB: 4096
+- msg: 'VOCAB: 8192'
+  update:
+    VOCAB: 8192
+- msg: 'VOCAB: 12345'
+  update:
+    VOCAB: 12345
+- msg: 'VOCAB: 98765'
+  update:
+    VOCAB: 98765
+- msg: 'VOCAB: 7777'
+  update:
+    VOCAB: 7777
+- msg: 'ROPE: 128'
+  update:
+    ROPE: 128
+- msg: 'ROPE: 256'
+  update:
+    ROPE: 256
+- msg: 'ROPE: 512'
+  update:
+    ROPE: 512
+- msg: 'ROPE: 1024k'
+  update:
+    ROPE: 1024000
+- msg: 'ROPE: 2048k'
+  update:
+    ROPE: 2048000
+- msg: 'ROPE: 4096k'
+  update:
+    ROPE: 4096000
+- msg: 'ROPE: 1000k'
+  update:
+    ROPE: 1000000
+- msg: 'ROPE: 16000k'
+  update:
+    ROPE: 16000000

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -9,6 +9,7 @@ from classifier import parse_reason
 def test_error_rules():
     rules_path = Path(__file__).parent.parent / "rules" / "error_rules.yaml"
     cases = yaml.safe_load(rules_path.read_text())
+    assert len(cases) > 50
     for case in cases:
         msg = case["msg"]
         expected = case["update"]

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -12,3 +12,19 @@ def test_planner_update_prunes_and_resets():
     combo = next(p)
     assert combo["TEXT_EMB_d"] == 4096
     assert p.candidates["TEXT_EMB_d"] == [4096]
+
+
+def test_planner_ordering():
+    defaults = {
+        "TEXT_EMB_d": [1, 2],
+        "HEAD": ["a", "b"],
+        "LATENT_C": [4],
+        "LATENT_SCALE": [8],
+        "VISION": ["V1", "V2"],
+    }
+    p = Planner(seed={}, defaults=defaults)
+    first = next(p)
+    second = next(p)
+    assert list(first.keys()) == ["TEXT_EMB_d", "HEAD", "LATENT_C", "LATENT_SCALE", "VISION"]
+    assert first["VISION"] != second["VISION"]
+    assert first["TEXT_EMB_d"] == second["TEXT_EMB_d"]

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -1,0 +1,77 @@
+from pathlib import Path
+import sys
+import numpy as np
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from classifier import parse_reason
+from reshell import _onnx_engine_forward, _llama_engine_forward
+
+
+# ---- ONNX -----------------------------------------------------------
+
+
+def _save_onnx_linear(in_features: int, path: Path) -> None:
+    import onnx
+    from onnx import helper, TensorProto
+
+    X = helper.make_tensor_value_info("input", TensorProto.FLOAT, [1, in_features])
+    W = helper.make_tensor("W", TensorProto.FLOAT, [in_features, 1], [0.0] * in_features)
+    B = helper.make_tensor("B", TensorProto.FLOAT, [1], [0.0])
+    Y = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1, 1])
+    node = helper.make_node("Gemm", ["input", "W", "B"], ["output"])
+    graph = helper.make_graph([node], "g", [X], [Y], [W, B])
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 10)])
+    model.ir_version = 10
+    onnx.save(model, path)
+
+
+def test_onnx_probe_success(tmp_path):
+    model = tmp_path / "lin.onnx"
+    _save_onnx_linear(3, model)
+    out = _onnx_engine_forward(model, {"x": np.zeros((1, 3), dtype=np.float32)})
+    assert out == "ok"
+
+
+def test_onnx_probe_failure_classified(tmp_path):
+    model = tmp_path / "lin.onnx"
+    _save_onnx_linear(3, model)
+    with pytest.raises(RuntimeError) as exc:
+        _onnx_engine_forward(model, {"x": np.zeros((1, 4), dtype=np.float32)})
+    assert parse_reason(str(exc.value)) == {"TEXT_EMB_d": 3}
+
+
+# ---- llama.cpp ------------------------------------------------------
+
+
+def test_llama_probe_success(monkeypatch, tmp_path):
+    class Dummy:
+        def __init__(self, *a, **k):
+            pass
+
+        def eval(self, tokens):
+            return None
+
+    import types
+    monkeypatch.setitem(sys.modules, "llama_cpp", types.SimpleNamespace(Llama=Dummy))
+    artifact = tmp_path / "model.gguf"
+    artifact.write_bytes(b"gguf")
+    out = _llama_engine_forward(artifact, {"token_id": 0})
+    assert out == "ok"
+
+
+def test_llama_probe_failure_classified(monkeypatch, tmp_path):
+    class Dummy:
+        def __init__(self, *a, **k):
+            pass
+
+        def eval(self, tokens):
+            raise RuntimeError("vocab 16 expected 32000")
+
+    import types
+    monkeypatch.setitem(sys.modules, "llama_cpp", types.SimpleNamespace(Llama=Dummy))
+    artifact = tmp_path / "model.gguf"
+    artifact.write_bytes(b"gguf")
+    with pytest.raises(RuntimeError) as exc:
+        _llama_engine_forward(artifact, {"token_id": 0})
+    assert parse_reason(str(exc.value)) == {"VOCAB": 32000}

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+import sys
+import time
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from sandbox import Sandbox, Limits
+
+
+def test_sandbox_timeout():
+    box = Sandbox(Limits(timeout=0.5))
+
+    def sleepy():
+        time.sleep(1)
+
+    with pytest.raises(TimeoutError):
+        box.try_forward(sleepy)
+
+
+def test_sandbox_memory_cap():
+    box = Sandbox(Limits(cpu_mem=10 * 1024 * 1024, timeout=2.0))
+
+    def eater():
+        _ = bytearray(20 * 1024 * 1024)
+        return "done"
+
+    with pytest.raises((RuntimeError, TimeoutError)):
+        box.try_forward(eater)


### PR DESCRIPTION
## Summary
- expand ONNX and llama.cpp probing with classification hints
- grow classifier rule set past fifty synthetic cases
- test planner ordering and sandbox resource limits

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a82a7a5534832c9633f6d12c3bac85