### PR TITLE
Expand planner with LLM-specific hints

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -17,9 +17,22 @@ DEFAULT_CANDIDATES: Dict[str, Sequence[Any]] = {
     "LATENT_C": [4, 8],
     "LATENT_SCALE": [8, 16],
     "VISION": ["ViT-L/14-grid", "ViT-H/14-grid", "SigLIP-H-map"],
+    # LLM-specific knobs
+    "VOCAB": [32000, 64000],
+    "ROPE": [128000, 256000],
+    "KV_DTYPE": ["f16", "f32"],
 }
 
-ORDER = ["TEXT_EMB_d", "HEAD", "LATENT_C", "LATENT_SCALE", "VISION"]
+ORDER = [
+    "TEXT_EMB_d",
+    "HEAD",
+    "LATENT_C",
+    "LATENT_SCALE",
+    "VISION",
+    "VOCAB",
+    "ROPE",
+    "KV_DTYPE",
+]
 
 
 def plan_candidates(
@@ -50,7 +63,7 @@ class Planner:
     """Iterate through probe candidate combinations.
 
     The enumeration order favours collapsing large uncertainties first:
-    ``TEXT_EMB_d → HEAD → LATENT_C → LATENT_SCALE → VISION``.
+    ``TEXT_EMB_d → HEAD → LATENT_C → LATENT_SCALE → VISION → VOCAB → ROPE → KV_DTYPE``.
     """
 
     seed: Mapping[str, Any] = field(default_factory=dict)

--- a/puppets.py
+++ b/puppets.py
@@ -18,10 +18,13 @@ except Exception:  # pragma: no cover - fallback
 __all__ = ["text_emb", "latent", "vision_grid", "kv_cache_probe"]
 
 
-def _randn(shape: Tuple[int, ...]):
+def _randn(shape: Tuple[int, ...], dtype: str | None = None):
+    """Generate random data with an optional dtype hint."""
     if _HAS_TORCH:
-        return torch.randn(shape)
-    return np.random.randn(*shape).astype(np.float32)
+        torch_dtype = torch.float16 if dtype == "f16" else torch.float32
+        return torch.randn(shape, dtype=torch_dtype)
+    np_dtype = np.float16 if dtype == "f16" else np.float32
+    return np.random.randn(*shape).astype(np_dtype)
 
 
 def text_emb(d: int):
@@ -48,7 +51,20 @@ def vision_grid(profile: str):
     return _randn(shape)
 
 
-def kv_cache_probe(n_heads: int, d_head: int, t: int = 2):
-    """Dummy key/value cache tensor for LLM probes."""
+def kv_cache_probe(n_heads: int, d_head: int, t: int = 2, dtype: str | None = None):
+    """Dummy key/value cache tensor for LLM probes.
+
+    Parameters
+    ----------
+    n_heads:
+        Number of attention heads.
+    d_head:
+        Dimension per head.
+    t:
+        Sequence length (default ``2``).
+    dtype:
+        Optional key/value dtype hint (e.g. ``"f16"`` or ``"f32"``).
+    """
+
     shape = (2, int(n_heads), t, int(d_head))
-    return _randn(shape)
+    return _randn(shape, dtype)

--- a/reshell.py
+++ b/reshell.py
@@ -95,10 +95,11 @@ def _onnx_engine_forward(artifact: Path, inputs: Dict[str, Any]) -> str:
 def _llama_engine_forward(artifact: Path, inputs: Dict[str, Any]) -> str:
     """Run a minimal llama.cpp step via :mod:`llama_cpp`.
 
-    The model's metadata is read when instantiating :class:`llama_cpp.Llama`.
-    We then perform a single evaluation step with a provided ``token_id``
-    (default ``0``).  Any exceptions are re-raised with extracted integers to
-    aid hypothesis updates.
+    ``inputs`` may include optional hints (``vocab``, ``rope``, ``kv_dtype``)
+    which are forwarded to the underlying :class:`llama_cpp.Llama` constructor
+    when available.  A single evaluation step is then executed with the
+    provided ``token_id`` (default ``0``).  Any exceptions are re-raised with
+    extracted integers to aid hypothesis updates.
     """
 
     import re
@@ -108,8 +109,20 @@ def _llama_engine_forward(artifact: Path, inputs: Dict[str, Any]) -> str:
         raise RuntimeError("LLAMA_CPP_MISSING") from e
 
     token_id = int(inputs.get("token_id", 0))
+    kv_dtype = inputs.get("kv_dtype")
+    rope = inputs.get("rope")
+    vocab = inputs.get("vocab")
+
+    kwargs = {}
+    if kv_dtype is not None:
+        kwargs["f16_kv"] = kv_dtype == "f16"
+    if rope is not None:
+        kwargs["rope_freq_base"] = int(rope)
+    if vocab is not None:
+        kwargs["vocab_only"] = True
+
     try:
-        llm = Llama(model_path=str(artifact), n_ctx=16, n_gpu_layers=0)
+        llm = Llama(model_path=str(artifact), n_ctx=16, n_gpu_layers=0, **kwargs)
         llm.eval([token_id])  # one-step evaluation
     except Exception as e:  # pragma: no cover - runtime failure path
         msg = str(e).lower()
@@ -188,6 +201,12 @@ def run_pipeline(artifact: Path, out_dir: Path) -> Tuple[Path, Path, Path]:
             puppet_inputs["latent"] = latent(combo["LATENT_C"], combo["LATENT_SCALE"])
         if "VISION" in combo:
             puppet_inputs["vision"] = vision_grid(combo["VISION"])
+        if "VOCAB" in combo:
+            puppet_inputs["vocab"] = combo["VOCAB"]
+        if "ROPE" in combo:
+            puppet_inputs["rope"] = combo["ROPE"]
+        if "KV_DTYPE" in combo:
+            puppet_inputs["kv_dtype"] = combo["KV_DTYPE"]
 
         try:
             sandbox.try_forward(_probe_engine_forward, artifact, puppet_inputs)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -21,10 +21,22 @@ def test_planner_ordering():
         "LATENT_C": [4],
         "LATENT_SCALE": [8],
         "VISION": ["V1", "V2"],
+        "VOCAB": [32000],
+        "ROPE": [128000],
+        "KV_DTYPE": ["f16"],
     }
     p = Planner(seed={}, defaults=defaults)
     first = next(p)
     second = next(p)
-    assert list(first.keys()) == ["TEXT_EMB_d", "HEAD", "LATENT_C", "LATENT_SCALE", "VISION"]
+    assert list(first.keys()) == [
+        "TEXT_EMB_d",
+        "HEAD",
+        "LATENT_C",
+        "LATENT_SCALE",
+        "VISION",
+        "VOCAB",
+        "ROPE",
+        "KV_DTYPE",
+    ]
     assert first["VISION"] != second["VISION"]
     assert first["TEXT_EMB_d"] == second["TEXT_EMB_d"]


### PR DESCRIPTION
## Summary
- add VOCAB, ROPE, and KV_DTYPE to planner defaults and ordering
- allow kv cache puppet to accept dtype hints
- forward LLM-specific parameters through run_pipeline and llama oracle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a82d945644832c972a4b6d515e8705