### PR TITLE
Load error patterns from YAML rules with safe fallback

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -2,11 +2,14 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import Any, Dict
+
+import yaml
 
 # Map hypothesis keys to regex patterns capturing the relevant value.
 # Patterns are intentionally broad and numeric groups are prioritised.
-ERROR_PATTERNS = {
+DEFAULT_ERROR_PATTERNS = {
     "TEXT_EMB_d": r"COND_DIM[:\s]+(?:expected\s+)?(\d+)",
     "LATENT_C": r"LATENT_C[:\s]+(?:expected\s+)?(\d+)",
     "HEAD": r"HEAD[:\s]+(?:expected\s+)?(epsilon|v|flow)",
@@ -18,6 +21,19 @@ ERROR_PATTERNS = {
     "VOCAB": r"VOCAB[=:\s]+(\d+)",
     "ROPE": r"ROPE[=:\s]+(\d+)(k)?",
 }
+
+ERROR_PATTERNS = DEFAULT_ERROR_PATTERNS.copy()
+
+# Attempt to extend ERROR_PATTERNS from YAML rules file.
+rules_path = Path(__file__).resolve().parent / "rules" / "error_rules.yaml"
+try:
+    loaded = yaml.safe_load(rules_path.read_text())
+    if isinstance(loaded, dict):
+        extra = {k: v for k, v in loaded.items() if isinstance(k, str) and isinstance(v, str)}
+        ERROR_PATTERNS.update(extra)
+except (FileNotFoundError, yaml.YAMLError, OSError):
+    # Fall back to default patterns silently if file missing or malformed.
+    pass
 
 
 def parse_reason(msg: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- Read optional error pattern overrides from `rules/error_rules.yaml` during import
- Merge YAML-defined regexes with built-in defaults so patterns are extendable
- Gracefully fall back to defaults if the rules file is missing or malformed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68a82d92e01c832cb9133efc2714e5b9