### PR TITLE
Implement cache lookup for sandbox probes

### DIFF
--- a/sandbox.py
+++ b/sandbox.py
@@ -10,7 +10,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from multiprocessing import Process, Queue
+from pathlib import Path
 from typing import Any, Callable, Mapping
+import hashlib
 import os
 import resource
 
@@ -34,6 +36,7 @@ class Sandbox:
 
     def __init__(self, limits: Limits | None = None) -> None:
         self.limits = limits or Limits()
+        self.cache: dict[tuple[str, str], tuple[str, Any]] = {}
 
     # Child process -------------------------------------------------
     def _worker(self, fn: Callable[..., Any], q: Queue, *args: Any, **kwargs: Any) -> None:
@@ -62,6 +65,22 @@ class Sandbox:
         *args, **kwargs:
             Passed directly to ``fn``.
         """
+        key: tuple[str, str] | None = None
+        if args and isinstance(args[0], (str, os.PathLike, Path)):
+            try:
+                artifact_path = Path(args[0])
+                artifact_sha256 = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+                sig_src = repr((args[1:], sorted(kwargs.items())))
+                probe_signature = hashlib.sha256(sig_src.encode()).hexdigest()
+                key = (artifact_sha256, probe_signature)
+            except Exception:
+                key = None
+            if key and key in self.cache:
+                status, payload = self.cache[key]
+                if status == "ok":
+                    return payload
+                raise RuntimeError(payload)
+
         q: Queue = Queue()
         p = Process(target=self._worker, args=(fn, q, *args), kwargs=kwargs)
         p.start()
@@ -73,6 +92,8 @@ class Sandbox:
         if q.empty():
             raise RuntimeError("sandbox produced no result")
         status, payload = q.get()
+        if key is not None:
+            self.cache[key] = (status, payload)
         if status == "ok":
             return payload
         raise RuntimeError(payload)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -26,3 +26,39 @@ def test_sandbox_memory_cap():
 
     with pytest.raises((RuntimeError, TimeoutError)):
         box.try_forward(eater)
+
+
+def test_sandbox_cache_success(tmp_path):
+    artifact = tmp_path / "a.bin"
+    artifact.write_bytes(b"hello")
+    box = Sandbox()
+    counter = artifact.with_suffix(".cnt")
+
+    def worker(path: Path, counter_path: Path) -> int:
+        with open(counter_path, "a") as fh:
+            fh.write("x")
+        return 10
+
+    assert box.try_forward(worker, artifact, counter) == 10
+    assert counter.read_text() == "x"
+    assert box.try_forward(worker, artifact, counter) == 10
+    assert counter.read_text() == "x"
+
+
+def test_sandbox_cache_error(tmp_path):
+    artifact = tmp_path / "b.bin"
+    artifact.write_bytes(b"hello")
+    box = Sandbox()
+    counter = artifact.with_suffix(".err")
+
+    def boom(path: Path, counter_path: Path) -> None:
+        with open(counter_path, "a") as fh:
+            fh.write("x")
+        raise ValueError("boom")
+
+    with pytest.raises(RuntimeError):
+        box.try_forward(boom, artifact, counter)
+    assert counter.read_text() == "x"
+    with pytest.raises(RuntimeError):
+        box.try_forward(boom, artifact, counter)
+    assert counter.read_text() == "x"


### PR DESCRIPTION
## Summary
- add artifact/probe cache to Sandbox for repeated probe deduplication
- compute SHA256 of artifact and probe signature, returning cached results before spawning a subprocess
- test caching for both successful and failing probes

## Testing
- `pytest tests/test_sandbox.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68a82d91f2cc832c95442b60ae025fed