### PR TITLE
Add ComfyUI format rendering for trace and obligations

### DIFF
--- a/printers.py
+++ b/printers.py
@@ -64,6 +64,65 @@ def contact_trace(hyp: Dict[str, Any], validation: Dict[str, Any] | None = None,
             if metrics:
                 trace = f"{trace} ({', '.join(metrics)})"
         return trace
+    if fmt == "comfy":
+        nodes: List[Dict[str, Any]] = []
+        edges: List[Dict[str, Any]] = []
+        node_ids: Dict[str, int] = {}
+
+        next_id = 1
+
+        def add_node(name: str, params: Dict[str, Any]) -> int:
+            nonlocal next_id
+            node = {"id": next_id, "type": name, "params": params}
+            nodes.append(node)
+            node_ids[name] = next_id
+            next_id += 1
+            return node["id"]
+
+        if "TEXT_EMB_d" in hyp:
+            add_node("TEXT_EMB", {"d": hyp["TEXT_EMB_d"]})
+        if "HEAD" in hyp:
+            add_node("UNET", {"head": hyp["HEAD"]})
+        if "LATENT_C" in hyp or "LATENT_SCALE" in hyp:
+            params: Dict[str, Any] = {}
+            if "LATENT_C" in hyp:
+                params["C"] = hyp["LATENT_C"]
+            if "LATENT_SCALE" in hyp:
+                params["scale"] = hyp["LATENT_SCALE"]
+            add_node("VAE", params)
+        if "VISION" in hyp:
+            add_node("VISION", {"profile": hyp["VISION"]})
+
+        # Edges expressing minimal data flow between nodes.
+        if "TEXT_EMB" in node_ids and "UNET" in node_ids:
+            edges.append({
+                "src": node_ids["TEXT_EMB"],
+                "dst": node_ids["UNET"],
+                "src_port": "cond",
+                "dst_port": "cond",
+            })
+        if "VAE" in node_ids and "UNET" in node_ids:
+            edges.append({
+                "src": node_ids["VAE"],
+                "dst": node_ids["UNET"],
+                "src_port": "latent",
+                "dst_port": "latent",
+            })
+            edges.append({
+                "src": node_ids["UNET"],
+                "dst": node_ids["VAE"],
+                "src_port": "latent",
+                "dst_port": "latent",
+            })
+        if "VISION" in node_ids and "UNET" in node_ids:
+            edges.append({
+                "src": node_ids["VISION"],
+                "dst": node_ids["UNET"],
+                "src_port": "vision",
+                "dst_port": "vision",
+            })
+
+        return {"nodes": nodes, "edges": edges}
     raise ValueError(f"unknown format: {fmt}")
 
 
@@ -80,6 +139,22 @@ def obligations(hyp: Dict[str, Any], fmt: str = "json") -> Any:
         return missing
     if fmt == "cli":
         return "\n".join(f"* {m}" for m in missing)
+    if fmt == "comfy":
+        nodes: List[Dict[str, Any]] = []
+        if "TEXT_EMB_d" not in hyp:
+            nodes.append({"type": "TEXT_ENCODER", "params": {"dim": None}})
+        vae_params: Dict[str, Any] = {}
+        if "LATENT_C" not in hyp:
+            vae_params["C"] = None
+        if "LATENT_SCALE" not in hyp:
+            vae_params["scale"] = None
+        if vae_params:
+            nodes.append({"type": "VAE", "params": vae_params})
+        if "HEAD" not in hyp:
+            nodes.append({"type": "UNET", "params": {"head": None}})
+        if "VISION" not in hyp:
+            nodes.append({"type": "VISION_ADAPTER", "params": {"profile": None}})
+        return nodes
     raise ValueError(f"unknown format: {fmt}")
 
 
@@ -96,6 +171,6 @@ def proof(log: Iterable[str], validation: Dict[str, Any] | None = None, fmt: str
         lines.append(f"validate {validation}")
     if fmt == "json":
         return lines
-    if fmt == "cli":
+    if fmt in {"cli", "comfy"}:
         return "\n".join(lines)
     raise ValueError(f"unknown format: {fmt}")

--- a/tests/test_printers.py
+++ b/tests/test_printers.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import printers
+
+
+def test_contact_trace_comfy():
+    hyp = {
+        "TEXT_EMB_d": 2048,
+        "HEAD": "epsilon",
+        "LATENT_C": 4,
+        "LATENT_SCALE": 8,
+        "VISION": "ViT-H/14-grid",
+    }
+    trace = printers.contact_trace(hyp, fmt="comfy")
+    nodes = {n["type"]: n for n in trace["nodes"]}
+    assert nodes["TEXT_EMB"]["params"] == {"d": 2048}
+    assert nodes["UNET"]["params"] == {"head": "epsilon"}
+    assert nodes["VAE"]["params"] == {"C": 4, "scale": 8}
+    assert nodes["VISION"]["params"] == {"profile": "ViT-H/14-grid"}
+    edges = trace["edges"]
+    ids = {typ: nodes[typ]["id"] for typ in nodes}
+    assert {"src": ids["TEXT_EMB"], "dst": ids["UNET"], "src_port": "cond", "dst_port": "cond"} in edges
+    assert {"src": ids["VAE"], "dst": ids["UNET"], "src_port": "latent", "dst_port": "latent"} in edges
+    assert {"src": ids["UNET"], "dst": ids["VAE"], "src_port": "latent", "dst_port": "latent"} in edges
+    assert {"src": ids["VISION"], "dst": ids["UNET"], "src_port": "vision", "dst_port": "vision"} in edges
+
+
+def test_obligations_comfy():
+    hyp = {"TEXT_EMB_d": 2048}
+    oblig = printers.obligations(hyp, fmt="comfy")
+    nodes = {n["type"]: n for n in oblig}
+    assert "TEXT_ENCODER" not in nodes
+    assert nodes["UNET"]["params"] == {"head": None}
+    assert nodes["VAE"]["params"] == {"C": None, "scale": None}
+    assert nodes["VISION_ADAPTER"]["params"] == {"profile": None}
+
+
+def test_proof_ignores_comfy():
+    log = ["a", "b"]
+    assert printers.proof(log, fmt="comfy") == printers.proof(log, fmt="cli")


### PR DESCRIPTION
## Summary
- extend `contact_trace` and `obligations` to render a minimal ComfyUI node/edge graph
- keep `proof` to CLI/JSON formats even when `comfy` is requested
- cover new ComfyUI branches with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a82d8efd44832ca7f1fc97329a7279