### PR TITLE
Add disk-backed probe cache for sandbox

### DIFF
--- a/printers.py
+++ b/printers.py
@@ -133,7 +133,9 @@ def obligations(hyp: Dict[str, Any], fmt: str = "json") -> Any:
     messages.
     """
 
-    missing = [template.format("?") for key, template in _OBLIGATION_TEMPLATES.items() if key not in hyp]
+    missing = [
+        template.format(hyp.get(key, "?")) for key, template in _OBLIGATION_TEMPLATES.items()
+    ]
 
     if fmt == "json":
         return missing

--- a/reshell.py
+++ b/reshell.py
@@ -56,13 +56,18 @@ def _parse_guess(guess: str | None) -> Dict[str, Any]:
     return result
 
 
-def _parse_limits(limits: str | None) -> Dict[str, int | float]:
-    """Parse ``--limits`` into ``spawn_sandbox`` kwargs."""
+def _parse_limits(limits: str | None) -> Dict[str, int | float | str]:
+    """Parse ``--limits`` into ``spawn_sandbox`` kwargs.
 
-    result: Dict[str, int | float] = {}
+    Supported keys include ``timeout``, ``vram``, ``cpu_mem`` and
+    ``cache_dir``.
+    """
+
+    result: Dict[str, int | float | str] = {}
     for key, val in _parse_assignments(limits).items():
         lk = key.strip()
-        lv = val.strip().lower()
+        lv_raw = val.strip()
+        lv = lv_raw.lower()
         if lk == "timeout":
             if lv.endswith("s"):
                 lv = lv[:-1]
@@ -82,6 +87,8 @@ def _parse_limits(limits: str | None) -> Dict[str, int | float]:
                 result[lk] = int(float(lv) * mult)
             except ValueError:
                 pass
+        elif lk in {"cache", "cache_dir"}:
+            result["cache_dir"] = lv_raw
     return result
 
 
@@ -248,7 +255,7 @@ def run_pipeline(
     artifact: Path,
     out_dir: Path,
     guesses: Mapping[str, Any] | None = None,
-    limits: Mapping[str, int | float] | None = None,
+    limits: Mapping[str, Any] | None = None,
     fmt: str | None = None,
 ) -> Tuple[Path, Path, Path]:
     """Run a tiny probing loop over candidate combinations."""
@@ -260,7 +267,9 @@ def run_pipeline(
     if guesses:
         hypotheses.update(guesses)
     planner = Planner(seed=hypotheses)
-    sandbox = spawn_sandbox(limits)
+    limits_dict = dict(limits) if limits else {}
+    cache_dir = limits_dict.pop("cache_dir", None)
+    sandbox = spawn_sandbox(limits_dict or None, cache_dir=cache_dir)
 
     proof_log: list[str] = []
     validation: Dict[str, Any] | None = None
@@ -326,7 +335,8 @@ def _run(
     guess:
         Optional hypothesis overrides (``key=value`` pairs).
     limits:
-        Optional sandbox limits (``timeout=2s,vram=1GB``).
+        Optional sandbox limits and cache directory
+        (``timeout=2s,vram=1GB,cache_dir=/tmp/cache``).
     fmt:
         Optional printer output format.
     """
@@ -347,7 +357,11 @@ def main() -> None:
     parser.add_argument("--artifact", required=True, help="path to model artifact")
     parser.add_argument("--out", default="out", help="output directory for results")
     parser.add_argument("--guess", help="seed hypotheses", default=None)
-    parser.add_argument("--limits", help="resource limits", default=None)
+    parser.add_argument(
+        "--limits",
+        help="resource limits and cache (timeout=2s,vram=1GB,cache_dir=/tmp/cache)",
+        default=None,
+    )
     parser.add_argument("--format", dest="fmt", help="printer output format", default=None)
     args = parser.parse_args()
 

--- a/sandbox.py
+++ b/sandbox.py
@@ -13,6 +13,7 @@ from multiprocessing import Process, Queue
 from pathlib import Path
 from typing import Any, Callable, Mapping
 import hashlib
+import json
 import os
 import resource
 
@@ -34,9 +35,36 @@ class Limits:
 class Sandbox:
     """Run engine helpers inside an isolated subprocess."""
 
-    def __init__(self, limits: Limits | None = None) -> None:
+    def __init__(self, limits: Limits | None = None, cache_dir: str | Path | None = None) -> None:
         self.limits = limits or Limits()
         self.cache: dict[tuple[str, str], tuple[str, Any]] = {}
+        self.cache_file: Path | None = None
+        if cache_dir is not None:
+            self.cache_file = Path(cache_dir) / "sandbox_cache.json"
+            self.cache_file.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                if self.cache_file.exists():
+                    data = json.loads(self.cache_file.read_text())
+                    for k, v in data.items():
+                        a, b = k.split(":", 1)
+                        self.cache[(a, b)] = tuple(v)  # type: ignore[assignment]
+            except Exception:  # pragma: no cover - corrupted cache
+                pass
+
+    def _save_cache(self) -> None:
+        if not self.cache_file:
+            return
+        data = {f"{k[0]}:{k[1]}": list(v) for k, v in self.cache.items()}
+        tmp = self.cache_file.with_suffix(".tmp")
+        try:
+            tmp.write_text(json.dumps(data))
+            tmp.replace(self.cache_file)
+        except Exception:  # pragma: no cover - write errors
+            if tmp.exists():
+                try:
+                    tmp.unlink()
+                except Exception:
+                    pass
 
     # Child process -------------------------------------------------
     def _worker(self, fn: Callable[..., Any], q: Queue, *args: Any, **kwargs: Any) -> None:
@@ -94,6 +122,7 @@ class Sandbox:
         status, payload = q.get()
         if key is not None:
             self.cache[key] = (status, payload)
+            self._save_cache()
         if status == "ok":
             return payload
         raise RuntimeError(payload)
@@ -152,9 +181,11 @@ class Sandbox:
 
 
 # Factory -----------------------------------------------------------
-def spawn_sandbox(limits: Mapping[str, int | float] | None = None) -> Sandbox:
-    """Create a :class:`Sandbox` with ``limits``."""
+def spawn_sandbox(
+    limits: Mapping[str, int | float] | None = None, cache_dir: str | Path | None = None
+) -> Sandbox:
+    """Create a :class:`Sandbox` with ``limits`` and optional cache."""
 
     if limits is None:
-        return Sandbox()
-    return Sandbox(Limits(**limits))
+        return Sandbox(cache_dir=cache_dir)
+    return Sandbox(Limits(**limits), cache_dir=cache_dir)

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -62,3 +62,23 @@ def test_sandbox_cache_error(tmp_path):
     with pytest.raises(RuntimeError):
         box.try_forward(boom, artifact, counter)
     assert counter.read_text() == "x"
+
+
+def test_sandbox_disk_cache(tmp_path):
+    artifact = tmp_path / "c.bin"
+    artifact.write_bytes(b"hello")
+    counter = artifact.with_suffix(".cnt")
+    cache_dir = tmp_path / "cache"
+
+    def worker(path: Path, counter_path: Path) -> int:
+        with open(counter_path, "a") as fh:
+            fh.write("x")
+        return 5
+
+    box = Sandbox(cache_dir=cache_dir)
+    assert box.try_forward(worker, artifact, counter) == 5
+    assert counter.read_text() == "x"
+
+    box2 = Sandbox(cache_dir=cache_dir)
+    assert box2.try_forward(worker, artifact, counter) == 5
+    assert counter.read_text() == "x"


### PR DESCRIPTION
## Summary
- allow Sandbox and spawn_sandbox to persist probe results in an optional cache directory
- support `cache_dir` in `reshell --limits` and document it in CLI help
- ensure obligation printer always emits component requirements and test disk-backed cache

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8636a4428832ca4e0023a05a764b0