### PR TITLE
docs: outline stage 2 roadmap and clarify reshell usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,18 @@
 
 ## Installation
 
-Install the package and its command-line interface with:
+Install the toolkit from PyPI:
 
 ```bash
-pip install .
+pip install aumlit
 ```
 
 ## Usage
 
-After installation the `reshell` command becomes available:
+After installation the `aumlit` command exposes the `reshell` subcommand:
 
 ```bash
-reshell --artifact path/to/model.safetensors --out out_dir
+aumlit reshell path/to/model.safetensors --out out_dir
 ```
 
 The command prints placeholder locations for `contact_trace.json`, `obligations.json`, and `proof.txt`.

--- a/docs/RESHELL.md
+++ b/docs/RESHELL.md
@@ -1,5 +1,8 @@
 # Reshell Overview
 
+`reshell` is a subcommand of the `aumlit` CLI that reconstructs the minimal
+workflow needed to run an unknown model file.
+
 ## Foundational Libraries
 - safetensors – read tensor weights without pickling risk.
 - torch – primary engine for UNet/T2I probes.
@@ -20,7 +23,9 @@
 8. Stretch goals: GGUF/LLM probing, simple planner, hardened sandbox, more node types.
 
 ## Vision
-Drop an unknown model file into aumlit, run `reshell`, and receive a minimal workflow mapping the model, listing required tools and the I/O contact points needed to run it.
+Drop an unknown model file into aumlit, run `aumlit reshell`, and receive a minimal
+workflow mapping the model, listing required tools and the I/O contact points needed
+to run it.
 
 ## Project Summary
 The repository is laying out a safety-oriented probing engine for unknown model files. It runs tiny, bounded tests against real execution backends (PyTorch, xFormers, llama.cpp, ONNX Runtime) to automatically derive a minimal contact trace of how the artifact should run, list any missing components as obligations, and record a proof transcript of all probe results. Design principles emphasize "real engines, tiny probes, typed reasons," strict loading policies (no pickles, resource caps, kill-on-timeout), and an initial scope around UNet-style T2I models, ControlNet variants, basic GGUF LLMs, and ONNX encoders/decoders.

--- a/docs/STAGE2.md
+++ b/docs/STAGE2.md
@@ -1,0 +1,40 @@
+# Stage 2 Roadmap for `aumlit reshell`
+
+## High-Leverage Upgrades
+1. **Geometry DSL** – normalize tensor shapes and arithmetic into a tiny shape algebra; regex becomes a feeder, planner consumes emitted constraints (e.g., `d == 2048`, `C ∈ {4,8}`, `scale | 8`).
+2. **Greedy planner** – score probes by cardinality collapse (`log|H_before| - log|H_after_if_fail|`) and respect tier ordering (EMB→HEAD→LATENT→VISION→LLM) with timeout-aware engine selection.
+3. **Enriched cache** – hash key plus outcome class, extracted ints, engine id, failing op, timings, and cross-artifact reuse for shared headers.
+4. **Minimum validation** – add stability, precision, and I/O sanity checks; flag unstable engines, dtype issues, or degenerate outputs.
+5. **Obligations with provenance** – attach origin info to each requirement (source constraint, op kind, proof line).
+6. **ONNX and GGUF signals** – leverage shape inference, dynamic axis checks, custom op detection, and GGUF header data before expensive probes.
+7. **xFormers layout oracle** – use mem-efficient toggle to infer attention layout and feed back into planner.
+8. **Error corpus & golden tests** – maintain `rules/error_rules.yaml` with exemplars and golden tests to ensure classifier resilience.
+9. **CLI ergonomics** – richer flags (`--fmt`, `--guess`, presets `--fast`/`--deep`) and proof limits.
+10. **ComfyUI bridge** – export minimal graphs with TODO nodes, shape annotations, and re-prove button inside Comfy.
+
+## Failure Modes to Pin Down Early
+- Silent success with wrong semantics.
+- Error phrasing drift.
+- Probe side-effects from JIT/caching.
+- OOM from pathological headers.
+- Heisenbugs from parallelism.
+
+## Quick Hits
+- Implement constraint objects and switch classifier to emit `ConstraintSet`.
+- Add latent scales 4 & 32 with single conv probes.
+- Record failing op kind uniformly.
+- Support `--proof-limit` and emit best partial trace.
+- Ship `examples/` with TorchScript, ONNX, GGUF fixtures.
+
+## Stretch Ideas
+- Witness minimisation for smallest validating inputs.
+- ONNX graph fingerprinting to hint model family.
+- Constraint SAT solver to prune candidate space.
+
+## Metrics
+- **Collapse rate** – probes to reach ready state.
+- **Correctness** – accuracy of inferred dimensions and types.
+- **Robustness** – classifier coverage across engine versions.
+- **Safety** – watchdog kills, resource usage stats.
+- **UX** – time-to-first-useful-obligation.
+


### PR DESCRIPTION
## Summary
- add Stage 2 roadmap for `aumlit reshell`
- note that `reshell` is run as an `aumlit` subcommand in README and docs

## Testing
- `pytest` *(fails: `test_run_pipeline_cli_format`, `test_run_pipeline_multiple_hints`)*

------
https://chatgpt.com/codex/tasks/task_e_68a9059a338c832ca618890158d5a643