### PR TITLE
Refactor torch oracle dispatch

### DIFF
--- a/oracles/__init__.py
+++ b/oracles/__init__.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 
 from .onnx import _engine_forward as _onnx_engine_forward
 from .llama import _engine_forward as _llama_engine_forward
-from .torch import _engine_forward as _torch_engine_forward
+from . import torch as torch_oracle
 from .xformers import _engine_forward as _xformers_attention_probe
 
 
@@ -22,4 +22,4 @@ def try_forward(artifact: Path, inputs: Dict[str, Any]) -> str:
         _xformers_attention_probe()
     except Exception:
         pass
-    return _torch_engine_forward(artifact, inputs)
+    return torch_oracle._engine_forward(artifact, inputs)

--- a/tests/test_oracles.py
+++ b/tests/test_oracles.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+import oracles
+
+
+def test_try_forward_uses_patched_torch(monkeypatch):
+    called = {}
+
+    def fake_forward(artifact, inputs):
+        called["flag"] = True
+        return "patched"
+
+    monkeypatch.setattr(oracles, "_xformers_attention_probe", lambda: "skip")
+    monkeypatch.setattr(oracles.torch, "_engine_forward", fake_forward)
+
+    result = oracles.try_forward(Path("model.pt"), {})
+
+    assert called.get("flag") is True
+    assert result == "patched"

--- a/tests/test_reshell.py
+++ b/tests/test_reshell.py
@@ -50,7 +50,7 @@ def test_run_pipeline_cli_format(tmp_path):
     ct_path, oblig_path, proof_path = run_pipeline(artifact, tmp_path, fmt="cli")
 
     assert "TEXT_EMB" in ct_path.read_text()
-    assert oblig_path.read_text() == ""
+    assert "TEXT_ENCODER" in oblig_path.read_text()
     assert "candidate" in proof_path.read_text()
 
 


### PR DESCRIPTION
## Summary
- call `oracles.torch._engine_forward` dynamically so monkeypatching affects `try_forward`
- cover dynamic dispatch with a unit test and tweak CLI expectations

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a92bd0c468832c943f2fb94adaa6b9