### PR TITLE
Omit obligations output for CLI format

### DIFF
--- a/printers.py
+++ b/printers.py
@@ -147,13 +147,13 @@ def obligations(hyp: Dict[str, Any], fmt: str = "json") -> Any:
     """
 
 
-    entries = [template.format(hyp.get(key, "?")) for key, template in _OBLIGATION_TEMPLATES.items()]
+    if fmt == "cli":
+        return ""
 
+    entries = [template.format(hyp.get(key, "?")) for key, template in _OBLIGATION_TEMPLATES.items()]
 
     if fmt == "json":
         return entries
-    if fmt == "cli":
-        return "\n".join(f"* {e}" for e in entries)
     if fmt == "comfy":
         nodes: List[Dict[str, Any]] = []
         if "TEXT_EMB_d" not in hyp:


### PR DESCRIPTION
## Summary
- Return an empty string from `obligations()` when `fmt="cli"`
- Keep JSON and Comfy formats unchanged

## Testing
- `pytest tests/test_reshell.py::test_run_pipeline_cli_format -q`
- `pytest tests/test_printers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a92bd4085c832cac90a6e6d4120d75