### PR TITLE
Use incremental hashing for sandbox cache

### DIFF
--- a/sandbox.py
+++ b/sandbox.py
@@ -97,7 +97,11 @@ class Sandbox:
         if args and isinstance(args[0], (str, os.PathLike, Path)):
             try:
                 artifact_path = Path(args[0])
-                artifact_sha256 = hashlib.sha256(artifact_path.read_bytes()).hexdigest()
+                hasher = hashlib.sha256()
+                with artifact_path.open("rb") as fh:
+                    for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                        hasher.update(chunk)
+                artifact_sha256 = hasher.hexdigest()
                 sig_src = repr((args[1:], sorted(kwargs.items())))
                 probe_signature = hashlib.sha256(sig_src.encode()).hexdigest()
                 key = (artifact_sha256, probe_signature)


### PR DESCRIPTION
## Summary
- compute artifact hash incrementally in `Sandbox.try_forward` to reduce memory usage during cache key generation

## Testing
- `pytest` *(fails: tests/test_reshell.py::test_run_pipeline_cli_format)*

------
https://chatgpt.com/codex/tasks/task_e_68a92ebdab5c832c81d846f7e559e667