### PR TITLE
Improve error message quote stripping

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -38,8 +38,10 @@ except (FileNotFoundError, yaml.YAMLError, OSError):
 
 def parse_reason(msg: str) -> Dict[str, Any]:
     """Extract all hypothesis updates from ``msg`` using regex rules."""
-    if "'" in msg:
-        msg = msg.split("'", 2)[1]
+    msg = msg.strip()
+    m = re.match(r"^(['\"])(.*)\1$", msg)
+    if m:
+        msg = m.group(2)
     updates: Dict[str, Any] = {}
     for key, pattern in ERROR_PATTERNS.items():
         for m in re.finditer(pattern, msg, re.IGNORECASE):

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -19,3 +19,8 @@ def test_error_rules():
 def test_multiple_hints_collected():
     msg = "COND_DIM: expected 4 LATENT_C: expected 8"
     assert parse_reason(msg) == {"TEXT_EMB_d": 4, "LATENT_C": 8}
+
+
+def test_surrounding_quotes_removed_but_inner_preserved():
+    msg = "'LATENT_C: expected 4 and 'inner' noise'"
+    assert parse_reason(msg) == {"LATENT_C": 4}


### PR DESCRIPTION
## Summary
- handle surrounding quotes in error messages without splitting inner ones
- cover quote-stripping edge case in classifier tests

## Testing
- `pytest tests/test_classifier.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'oracles')*

------
https://chatgpt.com/codex/tasks/task_e_68a92ebe5334832c94ada5f66f2b90b7