### PR TITLE
Guard against malformed safetensors headers

### DIFF
--- a/headers.py
+++ b/headers.py
@@ -44,7 +44,11 @@ def read_safetensors_header(path: Path | str) -> Meta:
     p = _ensure_path(path)
     with p.open("rb") as f:
         header_len = int.from_bytes(f.read(8), "little")
-        header = json.loads(f.read(header_len).decode("utf-8"))
+        raw_header = f.read(header_len)
+    try:
+        header = json.loads(raw_header.decode("utf-8"))
+    except (json.JSONDecodeError, ValueError) as e:
+        raise RuntimeError("Malformed safetensors header") from e
 
     hints = header.get("__metadata__", {}) if isinstance(header, dict) else {}
     tensors = [

--- a/tests/test_headers.py
+++ b/tests/test_headers.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import headers
+import pytest
+
+
+def test_read_safetensors_header_malformed(tmp_path):
+    bad_json = b'{"foo": 1'
+    path = tmp_path / "bad.safetensors"
+    path.write_bytes(len(bad_json).to_bytes(8, "little") + bad_json)
+    with pytest.raises(RuntimeError, match="Malformed safetensors header"):
+        headers.read_safetensors_header(path)
+


### PR DESCRIPTION
## Summary
- Raise RuntimeError when `.safetensors` header JSON is malformed
- Add test that corrupts a `.safetensors` file to validate error

## Testing
- `pytest tests/test_headers.py -q`
- `pytest -q` *(fails: No module named 'yaml', 'numpy', 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68a92ebf91fc832c85b92ec2aa6a3d2b