### PR TITLE
Render obligations in CLI format

### DIFF
--- a/printers.py
+++ b/printers.py
@@ -147,10 +147,10 @@ def obligations(hyp: Dict[str, Any], fmt: str = "json") -> Any:
     """
 
 
-    if fmt == "cli":
-        return ""
-
     entries = [template.format(hyp.get(key, "?")) for key, template in _OBLIGATION_TEMPLATES.items()]
+
+    if fmt == "cli":
+        return "\n".join(entries)
 
     if fmt == "json":
         return entries

--- a/tests/test_printers.py
+++ b/tests/test_printers.py
@@ -42,6 +42,13 @@ def test_obligations_comfy():
     assert nodes["AUDIO_ENCODER"]["params"] == {"shape": None}
 
 
+def test_obligations_cli():
+    hyp = {"TEXT_EMB_d": 2048}
+    oblig_cli = printers.obligations(hyp, fmt="cli")
+    oblig_json = printers.obligations(hyp, fmt="json")
+    assert oblig_cli == "\n".join(oblig_json)
+
+
 def test_proof_ignores_comfy():
     log = ["a", "b"]
     assert printers.proof(log, fmt="comfy") == printers.proof(log, fmt="cli")


### PR DESCRIPTION
## Summary
- Join obligation entries with newlines for CLI output
- Test CLI obligations renderer

## Testing
- `pytest -q` *(fails: OSError: /root/.pyenv/versions/3.12.10/lib/python3.12/site-packages/torch/lib/libtorch_global_deps.so: cannot open shared object file)*
- `pytest tests/test_printers.py::test_obligations_cli -q`

------
https://chatgpt.com/codex/tasks/task_e_68a92ec02a80832c9dab4f9781db28bb