### PR TITLE
Add header-class cache for probe results

### DIFF
--- a/headers.py
+++ b/headers.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 import json
+import hashlib
 
 
 @dataclass
@@ -57,6 +58,21 @@ def read_safetensors_header(path: Path | str) -> Meta:
         if name != "__metadata__"
     ]
     return Meta(tensors=tensors, hints=dict(hints))
+
+
+def header_class_key(meta: Meta) -> str:
+    """Compute a stable key representing the header class.
+
+    The key is a SHA256 hash over tensor names/shapes and scalar hints,
+    allowing cross-artifact reuse when headers match.
+    """
+
+    data = {
+        "tensors": [(t.name, t.shape) for t in meta.tensors],
+        "hints": meta.hints,
+    }
+    blob = json.dumps(data, sort_keys=True).encode("utf-8")
+    return hashlib.sha256(blob).hexdigest()
 
 
 def read_onnx_header(path: Path | str) -> Meta:
@@ -123,4 +139,5 @@ __all__ = [
     "read_safetensors_header",
     "read_onnx_header",
     "read_gguf_header",
+    "header_class_key",
 ]

--- a/reshell.py
+++ b/reshell.py
@@ -15,7 +15,13 @@ from typing import Any, Dict, Mapping, Tuple
 
 from classifier import parse_reason
 
-from headers import Meta, read_gguf_header, read_onnx_header, read_safetensors_header
+from headers import (
+    Meta,
+    read_gguf_header,
+    read_onnx_header,
+    read_safetensors_header,
+    header_class_key,
+)
 from planner import Planner
 from printers import contact_trace, obligations, proof
 from puppets import audio_mel, latent, text_emb, vision_grid
@@ -93,6 +99,24 @@ def _parse_limits(limits: str | None) -> Dict[str, int | float | str]:
     return result
 
 
+def _load_header_cache(cache_dir: Path | str) -> Dict[str, Any]:
+    path = Path(cache_dir) / "header_cache.json"
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text())
+    except Exception:
+        return {}
+
+
+def _save_header_cache(cache_dir: Path | str, cache: Mapping[str, Any]) -> None:
+    path = Path(cache_dir) / "header_cache.json"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(cache))
+    tmp.replace(path)
+
+
 def _read_meta(artifact: Path) -> Meta:
     """Dispatch to the appropriate header reader based on suffix."""
 
@@ -116,50 +140,67 @@ def run_pipeline(
     fmt: str | None = None,
 ) -> Tuple[Path, Path, Path]:
     """Run a tiny probing loop over candidate combinations."""
-
     out_dir.mkdir(parents=True, exist_ok=True)
-    meta = _read_meta(artifact)
 
-    hypotheses: Dict[str, Any] = dict(meta.hints)
-    if guesses:
-        hypotheses.update(guesses)
-    planner = Planner(seed=hypotheses)
     limits_dict = dict(limits) if limits else {}
-    cache_dir = limits_dict.pop("cache_dir", None)
-    sandbox = spawn_sandbox(limits_dict or None, cache_dir=cache_dir)
+    cache_dir = limits_dict.get("cache_dir")
 
-    proof_log: list[str] = []
-    validation: Dict[str, Any] | None = None
-    for combo in planner:
-        puppet_inputs: Dict[str, Any] = {}
-        if "TEXT_EMB_d" in combo:
-            puppet_inputs["text"] = text_emb(combo["TEXT_EMB_d"])
-        if "LATENT_C" in combo and "LATENT_SCALE" in combo:
-            puppet_inputs["latent"] = latent(combo["LATENT_C"], combo["LATENT_SCALE"])
-        if "VISION" in combo:
-            puppet_inputs["vision"] = vision_grid(combo["VISION"])
-        if "AUDIO_SHAPE" in combo:
-            puppet_inputs["audio"] = audio_mel(combo["AUDIO_SHAPE"])
-        if "VOCAB" in combo:
-            puppet_inputs["vocab"] = combo["VOCAB"]
-        if "ROPE" in combo:
-            puppet_inputs["rope"] = combo["ROPE"]
-        if "KV_DTYPE" in combo:
-            puppet_inputs["kv_dtype"] = combo["KV_DTYPE"]
+    meta = _read_meta(artifact)
+    key = header_class_key(meta)
+    header_cache: Dict[str, Any] = _load_header_cache(cache_dir) if cache_dir else {}
 
-        try:
-            sandbox.try_forward(try_forward, artifact, puppet_inputs)
-            hypotheses.update(combo)
-            proof_log.append(f"candidate {combo} -> ok")
-            validation = sandbox.validate_min_run(try_forward, artifact, puppet_inputs)
-            break
-        except Exception as e:  # pragma: no cover - error path
-            reason = str(e)
-            updates = parse_reason(reason)
-            if updates:
-                hypotheses.update(updates)
-                planner.update(updates)
-            proof_log.append(f"candidate {combo} -> {reason}")
+    if cache_dir and key in header_cache:
+        entry = header_cache[key]
+        hypotheses = dict(entry.get("hypotheses", {}))
+        validation = entry.get("validation")
+        proof_log = [f"recognized header {key}"]
+        print(f"[reshell] recognized header {key}")
+    else:
+        hypotheses: Dict[str, Any] = dict(meta.hints)
+        if guesses:
+            hypotheses.update(guesses)
+        planner = Planner(seed=hypotheses)
+        cache_dir = limits_dict.pop("cache_dir", None)
+        sandbox = spawn_sandbox(limits_dict or None, cache_dir=cache_dir)
+
+        proof_log: list[str] = []
+        validation: Dict[str, Any] | None = None
+        for combo in planner:
+            puppet_inputs: Dict[str, Any] = {}
+            if "TEXT_EMB_d" in combo:
+                puppet_inputs["text"] = text_emb(combo["TEXT_EMB_d"])
+            if "LATENT_C" in combo and "LATENT_SCALE" in combo:
+                puppet_inputs["latent"] = latent(combo["LATENT_C"], combo["LATENT_SCALE"])
+            if "VISION" in combo:
+                puppet_inputs["vision"] = vision_grid(combo["VISION"])
+            if "AUDIO_SHAPE" in combo:
+                puppet_inputs["audio"] = audio_mel(combo["AUDIO_SHAPE"])
+            if "VOCAB" in combo:
+                puppet_inputs["vocab"] = combo["VOCAB"]
+            if "ROPE" in combo:
+                puppet_inputs["rope"] = combo["ROPE"]
+            if "KV_DTYPE" in combo:
+                puppet_inputs["kv_dtype"] = combo["KV_DTYPE"]
+
+            try:
+                sandbox.try_forward(try_forward, artifact, puppet_inputs)
+                hypotheses.update(combo)
+                proof_log.append(f"candidate {combo} -> ok")
+                validation = sandbox.validate_min_run(try_forward, artifact, puppet_inputs)
+                break
+            except Exception as e:  # pragma: no cover - error path
+                reason = str(e)
+                updates = parse_reason(reason)
+                if updates:
+                    hypotheses.update(updates)
+                    planner.update(updates)
+                proof_log.append(f"candidate {combo} -> {reason}")
+
+        if cache_dir:
+            header_cache[key] = {"hypotheses": hypotheses}
+            if validation:
+                header_cache[key]["validation"] = validation
+            _save_header_cache(cache_dir, header_cache)
 
     trace_out = contact_trace(hypotheses, validation, fmt=fmt or "json")
     oblig_out = obligations(hypotheses, fmt=fmt or "json")

--- a/tests/test_reshell.py
+++ b/tests/test_reshell.py
@@ -108,3 +108,29 @@ def test_run_pipeline_gguf_fixture(tmp_path):
     assert "candidate" in proof
     assert oblig_path.read_text()
 
+
+def test_run_pipeline_header_cache(monkeypatch, tmp_path):
+    artifact = tmp_path / "lin256.pt"
+    _save_linear(256, artifact)
+    cache_dir = tmp_path / "cache"
+
+    # first run populates cache
+    run_pipeline(artifact, tmp_path / "out1", limits={"cache_dir": cache_dir})
+
+    def fail(*_args, **_kwargs):
+        raise AssertionError("try_forward should not be called on cache hit")
+
+    monkeypatch.setattr(reshell, "try_forward", fail)
+
+    # second run with same headers should hit cache and skip probes
+    artifact2 = tmp_path / "lin256_copy.pt"
+    _save_linear(256, artifact2)
+    ct_path, oblig_path, proof_path = run_pipeline(
+        artifact2, tmp_path / "out2", limits={"cache_dir": cache_dir}
+    )
+
+    trace = json.loads(ct_path.read_text())
+    assert trace["hypotheses"]["TEXT_EMB_d"] == 256
+    assert "recognized header" in proof_path.read_text()
+    assert oblig_path.read_text()
+


### PR DESCRIPTION
## Summary
- hash model headers into a reusable header-class key
- reuse previously discovered capabilities when header-class cached
- skip probing on cache hit and log recognition notice

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a99366b654832cb81e55914e3689ab