### PR TITLE
Add file locking for cache writes and concurrency tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ aumlit reshell path/to/model.safetensors --out out_dir
 
 The command prints placeholder locations for `contact_trace.json`, `obligations.json`, and `proof.txt`.
 
+## Concurrency
+
+Cache files such as `failure_cache.json` and `header_cache.json` are written
+under a cross-platform file lock. This prevents concurrent `reshell` runs from
+corrupting the JSON when multiple processes update the same cache directory.
+
 ## Building standalone binaries
 
 Standalone binaries can be produced with [PyInstaller](https://pyinstaller.org/).

--- a/failure_cache.py
+++ b/failure_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 import json
 from typing import Dict, Mapping
+from filelock import FileLock
 
 
 class FailureCache:
@@ -44,9 +45,11 @@ class FailureCache:
     def _save(self) -> None:
         try:
             self.path.parent.mkdir(parents=True, exist_ok=True)
-            tmp = self.path.with_suffix(".tmp")
-            tmp.write_text(json.dumps(self.data))
-            tmp.replace(self.path)
+            lock = FileLock(str(self.path) + ".lock")
+            with lock:
+                tmp = self.path.with_suffix(".tmp")
+                tmp.write_text(json.dumps(self.data))
+                tmp.replace(self.path)
         except Exception:
             pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "numpy",
     "gguf",
     "PyYAML",
+    "filelock",
 ]
 
 [project.scripts]

--- a/reshell.py
+++ b/reshell.py
@@ -13,6 +13,7 @@ import json
 import hashlib
 from pathlib import Path
 from typing import Any, Dict, Mapping, Tuple
+from filelock import FileLock
 
 from classifier import parse_reason
 from planner import Planner, probe_signature
@@ -109,9 +110,11 @@ def _load_header_cache(cache_dir: Path | str) -> Dict[str, Any]:
 def _save_header_cache(cache_dir: Path | str, cache: Mapping[str, Any]) -> None:
     path = Path(cache_dir) / "header_cache.json"
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = path.with_suffix(".tmp")
-    tmp.write_text(json.dumps(cache))
-    tmp.replace(path)
+    lock = FileLock(str(path) + ".lock")
+    with lock:
+        tmp = path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(cache))
+        tmp.replace(path)
 
 
 def _read_meta(artifact: Path) -> Meta:

--- a/tests/test_failure_cache.py
+++ b/tests/test_failure_cache.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import sys
+import threading
+import json
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from failure_cache import FailureCache
@@ -31,3 +33,21 @@ def test_failure_cache_global_ops(tmp_path):
     # clear-all removes every entry
     fc.clear()
     assert fc.inspect() == {}
+
+
+def test_failure_cache_concurrent_writes(tmp_path):
+    cache_file = tmp_path / "f.json"
+
+    def worker(idx: int) -> None:
+        fc = FailureCache(cache_file)
+        fc.record(f"h{idx}", f"sig{idx}", "ERR")
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # File should remain valid JSON despite concurrent writes
+    data = json.loads(cache_file.read_text())
+    assert isinstance(data, dict)

--- a/tests/test_reshell.py
+++ b/tests/test_reshell.py
@@ -4,6 +4,7 @@ import sys
 
 import torch
 import pytest
+import threading
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import reshell
@@ -133,4 +134,23 @@ def test_run_pipeline_header_cache(monkeypatch, tmp_path):
     assert trace["hypotheses"]["TEXT_EMB_d"] == 256
     assert "recognized header" in proof_path.read_text()
     assert oblig_path.read_text()
+
+
+def test_header_cache_concurrent_writes(tmp_path):
+    cache_dir = tmp_path / "cache"
+
+    def worker(idx: int) -> None:
+        cache = reshell._load_header_cache(cache_dir)
+        cache[str(idx)] = idx
+        reshell._save_header_cache(cache_dir, cache)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # ensure resulting cache file is valid JSON
+    data = reshell._load_header_cache(cache_dir)
+    assert isinstance(data, dict)
 


### PR DESCRIPTION
## Summary
- guard failure cache writes with `FileLock` to avoid concurrent corruption
- protect header cache writes with the same lock mechanism
- document cache locking and test concurrent writers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa3dee6fe8832ca30e7aff22bdf96e