### PR TITLE
Add constraint system and integrate with classifier

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 
 import re
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import yaml
+
+from geometry import ConstraintSet, DimVar, Equality
 
 # Map hypothesis keys to regex patterns capturing the relevant value.
 # Patterns are intentionally broad and numeric groups are prioritised.
@@ -36,13 +38,14 @@ except (FileNotFoundError, yaml.YAMLError, OSError):
     pass
 
 
-def parse_reason(msg: str) -> Dict[str, Any]:
-    """Extract all hypothesis updates from ``msg`` using regex rules."""
+def parse_reason(msg: str) -> List[Equality]:
+    """Extract constraints from ``msg`` using regex rules."""
+
     msg = msg.strip()
     m = re.match(r"^(['\"])(.*)\1$", msg)
     if m:
         msg = m.group(2)
-    updates: Dict[str, Any] = {}
+    constraints: List[Equality] = []
     for key, pattern in ERROR_PATTERNS.items():
         for m in re.finditer(pattern, msg, re.IGNORECASE):
             val: Any = m.group(1)
@@ -50,8 +53,16 @@ def parse_reason(msg: str) -> Dict[str, Any]:
                 val = int(val)
                 if key == "ROPE" and m.group(2):
                     val *= 1000
-            updates[key] = val
-    return updates
+            constraints.append(Equality(DimVar(key), val))
+    return constraints
 
 
-__all__ = ["parse_reason", "ERROR_PATTERNS"]
+def constraints_from_error(msg: str) -> ConstraintSet:
+    """Parse ``msg`` into a ``ConstraintSet``."""
+
+    cs = ConstraintSet()
+    cs.add(*parse_reason(msg))
+    return cs
+
+
+__all__ = ["parse_reason", "constraints_from_error", "ERROR_PATTERNS"]

--- a/geometry.py
+++ b/geometry.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+"""Simple dimensional constraint utilities.
+
+This module provides tiny dataclasses for symbolic dimension variables and
+constraints.  It is intentionally lightweight – just enough for the probing
+loop to accumulate and solve equality/ divisibility rules extracted from
+engine errors.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, Mapping, List, Union
+
+
+@dataclass(frozen=True)
+class DimVar:
+    """Symbolic variable representing an unknown dimension."""
+
+    name: str
+
+
+class Constraint:
+    """Base constraint type."""
+
+    def propagate(self, assigns: Dict[str, Any]) -> bool:
+        """Update ``assigns`` with any information implied by the constraint.
+
+        Returns ``True`` if ``assigns`` was mutated.  Implementations may raise
+        ``ValueError`` if a contradiction is detected.
+        """
+
+        raise NotImplementedError
+
+
+@dataclass(frozen=True)
+class Equality(Constraint):
+    """Enforce that ``left`` equals ``right``."""
+
+    left: DimVar
+    right: Union[int, str, DimVar]
+
+    def propagate(self, assigns: Dict[str, Any]) -> bool:
+        lname = self.left.name
+        r = self.right
+        if isinstance(r, DimVar):
+            rname = r.name
+            if lname in assigns and rname in assigns:
+                if assigns[lname] != assigns[rname]:
+                    raise ValueError(f"{lname}={assigns[lname]} != {rname}={assigns[rname]}")
+                return False
+            if lname in assigns:
+                assigns[rname] = assigns[lname]
+                return True
+            if rname in assigns:
+                assigns[lname] = assigns[rname]
+                return True
+            return False
+        else:
+            if lname in assigns:
+                if assigns[lname] != r:
+                    raise ValueError(f"{lname}={assigns[lname]} != {r}")
+                return False
+            assigns[lname] = r
+            return True
+
+
+@dataclass(frozen=True)
+class Divisible(Constraint):
+    """Require that ``var`` is divisible by ``divisor``."""
+
+    var: DimVar
+    divisor: int
+
+    def propagate(self, assigns: Dict[str, Any]) -> bool:
+        name = self.var.name
+        if name in assigns:
+            val = assigns[name]
+            if isinstance(val, int) and val % self.divisor != 0:
+                raise ValueError(f"{val} not divisible by {self.divisor}")
+        return False
+
+
+@dataclass
+class ConstraintSet:
+    """Collection of constraints with a tiny solver."""
+
+    constraints: List[Constraint] = field(default_factory=list)
+
+    def add(self, *cons: Constraint) -> None:
+        self.constraints.extend(cons)
+
+    def extend(self, cons: Iterable[Constraint]) -> None:  # pragma: no cover - convenience
+        self.constraints.extend(cons)
+
+    def solve(self, seed: Mapping[str, Any] | None = None) -> Dict[str, Any]:
+        """Solve the constraint set returning concrete assignments.
+
+        The solver performs a naive propagation pass over the constraints until
+        no further progress can be made.
+        """
+
+        assigns: Dict[str, Any] = dict(seed or {})
+        changed = True
+        while changed:
+            changed = False
+            for c in self.constraints:
+                if c.propagate(assigns):
+                    changed = True
+        return assigns
+
+
+__all__ = ["DimVar", "Equality", "Divisible", "ConstraintSet"]

--- a/reshell.py
+++ b/reshell.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Mapping, Tuple
 from filelock import FileLock
 
 from classifier import parse_reason
+from geometry import ConstraintSet, DimVar, Equality
 from planner import Planner, probe_signature
 from failure_cache import FailureCache
 from headers import (
@@ -172,6 +173,9 @@ def run_pipeline(
         if guesses:
             hypotheses.update(guesses)
 
+        constraints = ConstraintSet([Equality(DimVar(k), v) for k, v in hypotheses.items()])
+        hypotheses = constraints.solve()
+
         # Avoid re-trying previously failed probe signatures for this header.
         planner = Planner(seed=hypotheses, failed_probes=set(known_failures.keys()))
 
@@ -202,6 +206,7 @@ def run_pipeline(
             try:
                 sandbox.try_forward(try_forward, artifact, puppet_inputs)
                 hypotheses.update(combo)
+                constraints.add(*(Equality(DimVar(k), v) for k, v in combo.items()))
                 proof_log.append(f"candidate {combo} -> ok")
                 validation = sandbox.validate_min_run(try_forward, artifact, puppet_inputs)
                 break
@@ -210,12 +215,14 @@ def run_pipeline(
                 updates = parse_reason(reason)
                 # Record the failure signature with a simple error class.
                 if failure_cache:
-                    err_cls = next(iter(updates), "OTHER") if updates else "OTHER"
+                    err_cls = updates[0].left.name if updates else "OTHER"
                     failure_cache.record(header_id, probe_signature(combo), err_cls)
                 # Feed updates back into hypotheses and planner.
                 if updates:
-                    hypotheses.update(updates)
-                    planner.update(updates)
+                    constraints.add(*updates)
+                    solved = constraints.solve()
+                    hypotheses.update(solved)
+                    planner.update(solved)
                 proof_log.append(f"candidate {combo} -> {reason}")
 
         if cache_dir:

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -4,6 +4,7 @@ import yaml
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from classifier import parse_reason
+from geometry import ConstraintSet
 
 
 def test_error_rules():
@@ -13,14 +14,14 @@ def test_error_rules():
     for case in cases:
         msg = case["msg"]
         expected = case["update"]
-        assert parse_reason(msg) == expected
+        assert ConstraintSet(parse_reason(msg)).solve() == expected
 
 
 def test_multiple_hints_collected():
     msg = "COND_DIM: expected 4 LATENT_C: expected 8"
-    assert parse_reason(msg) == {"TEXT_EMB_d": 4, "LATENT_C": 8}
+    assert ConstraintSet(parse_reason(msg)).solve() == {"TEXT_EMB_d": 4, "LATENT_C": 8}
 
 
 def test_surrounding_quotes_removed_but_inner_preserved():
     msg = "'LATENT_C: expected 4 and 'inner' noise'"
-    assert parse_reason(msg) == {"LATENT_C": 4}
+    assert ConstraintSet(parse_reason(msg)).solve() == {"LATENT_C": 4}

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,24 @@
+from geometry import DimVar, Equality, Divisible, ConstraintSet
+from classifier import parse_reason
+import pytest
+
+
+def test_equality_and_solve():
+    v = DimVar("X")
+    cs = ConstraintSet([Equality(v, 7)])
+    assert cs.solve() == {"X": 7}
+
+
+def test_divisible_constraint():
+    v = DimVar("Y")
+    cs = ConstraintSet([Equality(v, 8), Divisible(v, 4)])
+    assert cs.solve() == {"Y": 8}
+    cs_bad = ConstraintSet([Equality(v, 10), Divisible(v, 4)])
+    with pytest.raises(ValueError):
+        cs_bad.solve()
+
+
+def test_parse_reason_integration():
+    msg = "COND_DIM: expected 4 LATENT_C: expected 8"
+    cs = ConstraintSet(parse_reason(msg))
+    assert cs.solve() == {"TEXT_EMB_d": 4, "LATENT_C": 8}

--- a/tests/test_probes.py
+++ b/tests/test_probes.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from classifier import parse_reason
+from classifier import constraints_from_error
 from oracles.onnx import _engine_forward as _onnx_engine_forward
 from oracles.llama import _engine_forward as _llama_engine_forward
 
@@ -39,7 +39,7 @@ def test_onnx_probe_failure_classified(tmp_path):
     _save_onnx_linear(3, model)
     with pytest.raises(RuntimeError) as exc:
         _onnx_engine_forward(model, {"x": np.zeros((1, 4), dtype=np.float32)})
-    assert parse_reason(str(exc.value)) == {"TEXT_EMB_d": 3}
+    assert constraints_from_error(str(exc.value)).solve() == {"TEXT_EMB_d": 3}
 
 
 # ---- llama.cpp ------------------------------------------------------
@@ -75,4 +75,4 @@ def test_llama_probe_failure_classified(monkeypatch, tmp_path):
     artifact.write_bytes(b"gguf")
     with pytest.raises(RuntimeError) as exc:
         _llama_engine_forward(artifact, {"token_id": 0})
-    assert parse_reason(str(exc.value)) == {"VOCAB": 32000}
+    assert constraints_from_error(str(exc.value)).solve() == {"VOCAB": 32000}


### PR DESCRIPTION
## Summary
- introduce geometry module with dimensional variables and basic constraints
- teach classifier.parse_reason to emit constraints and provide helper to build ConstraintSets
- propagate constraints during probing so planner is updated with solved values
- add unit tests for constraint solver and adjust existing tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa64fef9bc832c9c41e94c0571c6fc