### PR TITLE
Implement greedy planner with constraint-aware scoring

### DIFF
--- a/planner.py
+++ b/planner.py
@@ -8,10 +8,14 @@ space is preserved for back-off.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from itertools import product
+from itertools import product, count
+from heapq import heappush, heappop
 import hashlib
 import json
-from typing import Any, Dict, Iterator, Mapping, Sequence, Set
+import math
+from typing import Any, Dict, Iterator, Mapping, Sequence, Set, List, Tuple
+
+from geometry import ConstraintSet
 
 DEFAULT_CANDIDATES: Dict[str, Sequence[Any]] = {
     "TEXT_EMB_d": [768, 1024, 1280, 1536, 2048, 4096],
@@ -83,33 +87,41 @@ class Planner:
     )
     order: Sequence[str] = field(default_factory=lambda: ORDER)
     failed_probes: Set[str] = field(default_factory=set)
+    _queue: List[Tuple[float, int, Dict[str, Any]]] = field(init=False, default_factory=list)
+    _counter: Iterator[int] = field(init=False, default_factory=count)
 
     def __post_init__(self) -> None:
         self.candidates = plan_candidates(self.seed, self.defaults)
-        keys = [k for k in self.order if k in self.candidates]
-        self._keys = keys
-        self._iter: Iterator[tuple[Any, ...]] = product(
-            *(self.candidates[k] for k in keys)
-        )
+        self._keys = [k for k in self.order if k in self.candidates]
+        self._build_queue()
+
+    def _build_queue(self) -> None:
+        self._queue = []
+        for values in product(*(self.candidates[k] for k in self._keys)):
+            combo = dict(zip(self._keys, values))
+            sig = probe_signature(combo)
+            if sig in self.failed_probes:
+                continue
+            score = -self.score(combo)
+            heappush(self._queue, (score, next(self._counter), combo))
+
+    def score(self, combo: Mapping[str, Any]) -> float:  # pragma: no cover - default
+        return 0.0
 
     def __iter__(self) -> "Planner":  # pragma: no cover - trivial
         return self
 
     def __next__(self) -> Dict[str, Any]:
-        while True:
-            values = next(self._iter)
-            combo = dict(zip(self._keys, values))
+        while self._queue:
+            _score, _idx, combo = heappop(self._queue)
             sig = probe_signature(combo)
-            if sig not in self.failed_probes:
-                return combo
+            if sig in self.failed_probes:
+                continue
+            return combo
+        raise StopIteration
 
     def update(self, hyp: Mapping[str, Any]) -> None:
-        """Prune candidate lists according to ``hyp`` and reset iteration.
-
-        Any key present in ``hyp`` is fixed to its provided value.  If the
-        value differs from the current candidate space the internal iterator is
-        rebuilt so subsequent ``next`` calls reflect the new hypothesis state.
-        """
+        """Prune candidate lists according to ``hyp`` and rebuild queue."""
 
         changed = False
         for key, val in hyp.items():
@@ -119,9 +131,39 @@ class Planner:
             self.candidates[key] = [val]
             changed = True
         if changed:
-            keys = [k for k in self.order if k in self.candidates]
-            self._keys = keys
-            self._iter = product(*(self.candidates[k] for k in keys))
+            self._keys = [k for k in self.order if k in self.candidates]
+            self._build_queue()
 
 
-__all__ = ["DEFAULT_CANDIDATES", "plan_candidates", "probe_signature", "Planner"]
+@dataclass
+class GreedyPlanner(Planner):
+    """Planner that ranks probes by estimated hypothesis collapse."""
+
+    constraints: ConstraintSet = field(default_factory=ConstraintSet)
+
+    def score(self, combo: Mapping[str, Any]) -> float:
+        solved = self.constraints.solve()
+        total = 1
+        for k in self._keys:
+            total *= 1 if k in solved else len(self.candidates[k])
+        best = 0.0
+        for k in self._keys:
+            if k in solved:
+                continue
+            klen = len(self.candidates[k])
+            if klen <= 1:
+                continue
+            after = total / klen
+            diff = math.log(total) - math.log(after)
+            if diff > best:
+                best = diff
+        return best
+
+
+__all__ = [
+    "DEFAULT_CANDIDATES",
+    "plan_candidates",
+    "probe_signature",
+    "Planner",
+    "GreedyPlanner",
+]

--- a/reshell.py
+++ b/reshell.py
@@ -17,7 +17,7 @@ from filelock import FileLock
 
 from classifier import parse_reason
 from geometry import ConstraintSet, DimVar, Equality
-from planner import Planner, probe_signature
+from planner import Planner, GreedyPlanner, probe_signature
 from failure_cache import FailureCache
 from headers import (
     Meta,
@@ -177,7 +177,12 @@ def run_pipeline(
         hypotheses = constraints.solve()
 
         # Avoid re-trying previously failed probe signatures for this header.
-        planner = Planner(seed=hypotheses, failed_probes=set(known_failures.keys()))
+        planner_cls = GreedyPlanner if constraints is not None else Planner
+        planner = planner_cls(
+            seed=hypotheses,
+            failed_probes=set(known_failures.keys()),
+            **({"constraints": constraints} if planner_cls is GreedyPlanner else {}),
+        )
 
         # Only pass non-cache args to the sandbox
         cache_dir = limits_dict.pop("cache_dir", None)

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -2,7 +2,8 @@ from pathlib import Path
 import sys
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
-from planner import Planner, probe_signature
+from planner import Planner, GreedyPlanner, probe_signature
+from geometry import ConstraintSet, DimVar, Equality
 
 
 def test_planner_update_prunes_and_resets():
@@ -51,3 +52,19 @@ def test_planner_skips_failed_probes():
     p = Planner(seed={}, defaults=defaults, order=["A", "B"], failed_probes={sig})
     combo = next(p)
     assert combo == {"A": 2, "B": 3}
+
+
+def test_greedy_planner_reorders_after_constraints():
+    defaults = {"A": [1, 2], "B": [3, 4]}
+    cs = ConstraintSet()
+    gp = GreedyPlanner(constraints=cs, seed={}, defaults=defaults, order=["A", "B"])
+    first = next(gp)
+    second_before = next(gp)
+    gp.failed_probes.add(probe_signature(first))
+    cs.add(Equality(DimVar("B"), first["B"]))
+    solved = cs.solve()
+    gp.update(solved)
+    second_after = next(gp)
+    assert second_after["B"] == first["B"]
+    assert second_after["A"] != first["A"]
+    assert second_after != second_before


### PR DESCRIPTION
## Summary
- add priority-queue based planning with new GreedyPlanner class scoring probes by hypothesis collapse
- use GreedyPlanner in reshell when constraints are available
- cover greedy ordering behavior with new tests

## Testing
- `pytest tests/test_planner.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa68fa2e48832cb0c7dece6a96914c