### PR TITLE
feat: enrich failure cache with engine metadata

### DIFF
--- a/failure_cache.py
+++ b/failure_cache.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import json
-from typing import Dict, Mapping
+from typing import Any, Dict, Mapping
 from filelock import FileLock
 
 
@@ -11,21 +11,51 @@ class FailureCache:
 
     def __init__(self, path: Path) -> None:
         self.path = path
-        self.data: Dict[str, Dict[str, str]] = {}
+        # ``data`` maps header hashes to probe signatures and failure details
+        self.data: Dict[str, Dict[str, Dict[str, Any]]] = {}
         try:
             if self.path.exists():
-                self.data = json.loads(self.path.read_text())
+                raw = json.loads(self.path.read_text())
+                # Coerce legacy formats to the new structure
+                for hh, bucket in raw.items():
+                    self.data[hh] = {}
+                    for sig, info in bucket.items():
+                        if isinstance(info, dict):
+                            self.data[hh][sig] = info
+                        else:  # legacy ``error_cls`` string
+                            self.data[hh][sig] = {
+                                "error_cls": info,
+                                "ints": {},
+                                "engine": None,
+                                "op_kind": None,
+                                "time_ms": None,
+                            }
         except Exception:
             self.data = {}
 
-    def get(self, header_hash: str) -> Dict[str, str]:
-        """Return mapping of probe signatures to error classes."""
+    def get(self, header_hash: str) -> Dict[str, Dict[str, Any]]:
+        """Return mapping of probe signatures to failure details."""
         return dict(self.data.get(header_hash, {}))
 
-    def record(self, header_hash: str, probe_sig: str, error_cls: str) -> None:
-        """Record ``probe_sig`` with ``error_cls`` under ``header_hash``."""
+    def record(
+        self,
+        header_hash: str,
+        probe_sig: str,
+        error_cls: str,
+        ints: Mapping[str, Any] | None = None,
+        engine: str | None = None,
+        op_kind: str | None = None,
+        time_ms: float | None = None,
+    ) -> None:
+        """Record ``probe_sig`` with metadata under ``header_hash``."""
         bucket = self.data.setdefault(header_hash, {})
-        bucket[probe_sig] = error_cls
+        bucket[probe_sig] = {
+            "error_cls": error_cls,
+            "ints": dict(ints or {}),
+            "engine": engine,
+            "op_kind": op_kind,
+            "time_ms": time_ms,
+        }
         self._save()
 
     def clear(self, header_hash: str | None = None) -> None:
@@ -36,7 +66,7 @@ class FailureCache:
             self.data.pop(header_hash, None)
         self._save()
 
-    def inspect(self, header_hash: str | None = None) -> Mapping[str, Dict[str, str]]:
+    def inspect(self, header_hash: str | None = None) -> Mapping[str, Dict[str, Dict[str, Any]]]:
         """Return current cache state or a single header entry."""
         if header_hash is None:
             return dict(self.data)

--- a/reshell.py
+++ b/reshell.py
@@ -191,6 +191,16 @@ def run_pipeline(
         proof_log: list[str] = []
         validation: Dict[str, Any] | None = None
 
+        def _engine_id(art: Path) -> str:
+            suf = art.suffix.lower()
+            if suf == ".onnx":
+                return "onnx"
+            if suf == ".gguf":
+                return "llama"
+            return "torch"
+
+        engine_name = _engine_id(artifact)
+
         for combo in planner:
             puppet_inputs: Dict[str, Any] = {}
             if "TEXT_EMB_d" in combo:
@@ -209,7 +219,7 @@ def run_pipeline(
                 puppet_inputs["kv_dtype"] = combo["KV_DTYPE"]
 
             try:
-                sandbox.try_forward(try_forward, artifact, puppet_inputs)
+                sandbox.try_forward(try_forward, artifact, puppet_inputs, engine=engine_name)
                 hypotheses.update(combo)
                 constraints.add(*(Equality(DimVar(k), v) for k, v in combo.items()))
                 proof_log.append(f"candidate {combo} -> ok")
@@ -221,7 +231,19 @@ def run_pipeline(
                 # Record the failure signature with a simple error class.
                 if failure_cache:
                     err_cls = updates[0].left.name if updates else "OTHER"
-                    failure_cache.record(header_id, probe_signature(combo), err_cls)
+                    ints_map = {u.left.name: u.right for u in updates}
+                    engine = getattr(e, "engine", engine_name)
+                    op_kind = getattr(e, "op_kind", None)
+                    time_ms = getattr(e, "time_ms", None)
+                    failure_cache.record(
+                        header_id,
+                        probe_signature(combo),
+                        err_cls,
+                        ints=ints_map,
+                        engine=engine,
+                        op_kind=op_kind,
+                        time_ms=time_ms,
+                    )
                 # Feed updates back into hypotheses and planner.
                 if updates:
                     constraints.add(*updates)

--- a/sandbox.py
+++ b/sandbox.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import os
 import resource
+import time
 
 
 @dataclass
@@ -37,7 +38,8 @@ class Sandbox:
 
     def __init__(self, limits: Limits | None = None, cache_dir: str | Path | None = None) -> None:
         self.limits = limits or Limits()
-        self.cache: dict[tuple[str, str], tuple[str, Any]] = {}
+        # cache maps (artifact_hash, probe_hash) -> (status, payload, time_ms, engine, op_kind)
+        self.cache: dict[tuple[str, str], tuple[str, Any, float, str, Any]] = {}
         self.cache_file: Path | None = None
         if cache_dir is not None:
             self.cache_file = Path(cache_dir) / "sandbox_cache.json"
@@ -47,7 +49,12 @@ class Sandbox:
                     data = json.loads(self.cache_file.read_text())
                     for k, v in data.items():
                         a, b = k.split(":", 1)
-                        self.cache[(a, b)] = tuple(v)  # type: ignore[assignment]
+                        if isinstance(v, list):
+                            # Support legacy cache entries with fewer fields
+                            while len(v) < 5:
+                                v.append(None)
+                            status, payload, t_ms, eng, opk = v
+                            self.cache[(a, b)] = (status, payload, t_ms or 0.0, eng or "", opk)
             except Exception:  # pragma: no cover - corrupted cache
                 pass
 
@@ -78,9 +85,10 @@ class Sandbox:
             mb = self.limits.vram // (1024 * 1024)
             os.environ["PYTORCH_CUDA_ALLOC_CONF"] = f"max_split_size_mb:{mb}"
         try:
-            q.put(("ok", fn(*args, **kwargs)))
+            q.put(("ok", fn(*args, **kwargs), None))
         except Exception as e:  # pragma: no cover - error path
-            q.put(("err", repr(e)))
+            op_kind = getattr(e, "op_kind", None)
+            q.put(("err", repr(e), op_kind))
 
     # Public API ----------------------------------------------------
     def try_forward(
@@ -88,6 +96,7 @@ class Sandbox:
         fn: Callable[..., Any],
         *args: Any,
         class_key: str | None = None,
+        engine: str | None = None,
         **kwargs: Any,
     ) -> Any:
         """Run ``fn`` under resource limits.
@@ -101,6 +110,8 @@ class Sandbox:
         """
         key: tuple[str, str] | None = None
         base_key: str | None = class_key
+        engine_id = engine or getattr(fn, "__name__", "")
+        start = time.perf_counter()
         if base_key is None and args and isinstance(args[0], (str, os.PathLike, Path)):
             try:
                 artifact_path = Path(args[0])
@@ -116,28 +127,37 @@ class Sandbox:
             probe_signature = hashlib.sha256(sig_src.encode()).hexdigest()
             key = (base_key, probe_signature)
             if key in self.cache:
-                status, payload = self.cache[key]
+                status, payload, t_ms, eng, opk = self.cache[key]
                 if status == "ok":
-                    return payload
-                raise RuntimeError(payload)
+                    return payload, t_ms, eng
+                err = RuntimeError(payload)
+                err.engine = eng
+                err.time_ms = t_ms
+                err.op_kind = opk
+                raise err
 
         q: Queue = Queue()
         p = Process(target=self._worker, args=(fn, q, *args), kwargs=kwargs)
         p.start()
         p.join(self.limits.timeout)
+        duration = (time.perf_counter() - start) * 1000.0
         if p.is_alive():
             p.terminate()
             p.join()
             raise TimeoutError("sandbox timed out")
         if q.empty():
             raise RuntimeError("sandbox produced no result")
-        status, payload = q.get()
+        status, payload, op_kind = q.get()
         if key is not None:
-            self.cache[key] = (status, payload)
+            self.cache[key] = (status, payload, duration, engine_id, op_kind)
             self._save_cache()
         if status == "ok":
-            return payload
-        raise RuntimeError(payload)
+            return payload, duration, engine_id
+        err = RuntimeError(payload)
+        err.engine = engine_id
+        err.time_ms = duration
+        err.op_kind = op_kind
+        raise err
 
     def validate_min_run(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Mapping[str, float]:
         """Run ``fn`` once more to collect timing and VRAM metrics."""

--- a/tests/test_failure_cache.py
+++ b/tests/test_failure_cache.py
@@ -10,10 +10,19 @@ from failure_cache import FailureCache
 def test_failure_cache_roundtrip(tmp_path):
     cache_file = tmp_path / "f.json"
     fc = FailureCache(cache_file)
-    fc.record("h", "sig", "ERR")
-    assert fc.get("h") == {"sig": "ERR"}
+    fc.record("h", "sig", "ERR", ints={"a": 1}, engine="torch", op_kind="mm", time_ms=1.2)
+    expected = {
+        "sig": {
+            "error_cls": "ERR",
+            "ints": {"a": 1},
+            "engine": "torch",
+            "op_kind": "mm",
+            "time_ms": 1.2,
+        }
+    }
+    assert fc.get("h") == expected
     fc2 = FailureCache(cache_file)
-    assert fc2.get("h") == {"sig": "ERR"}
+    assert fc2.get("h") == expected
     fc.clear("h")
     assert fc.get("h") == {}
 
@@ -21,13 +30,29 @@ def test_failure_cache_roundtrip(tmp_path):
 def test_failure_cache_global_ops(tmp_path):
     cache_file = tmp_path / "f.json"
     fc = FailureCache(cache_file)
-    fc.record("h1", "sig1", "ERR1")
-    fc.record("h2", "sig2", "ERR2")
+    fc.record("h1", "sig1", "ERR1", engine="e1")
+    fc.record("h2", "sig2", "ERR2", engine="e2")
 
     # inspect-all returns the entire dataset
     assert fc.inspect() == {
-        "h1": {"sig1": "ERR1"},
-        "h2": {"sig2": "ERR2"},
+        "h1": {
+            "sig1": {
+                "error_cls": "ERR1",
+                "ints": {},
+                "engine": "e1",
+                "op_kind": None,
+                "time_ms": None,
+            }
+        },
+        "h2": {
+            "sig2": {
+                "error_cls": "ERR2",
+                "ints": {},
+                "engine": "e2",
+                "op_kind": None,
+                "time_ms": None,
+            }
+        },
     }
 
     # clear-all removes every entry

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -40,9 +40,14 @@ def test_sandbox_cache_success(tmp_path):
             fh.write("x")
         return 10
 
-    assert box.try_forward(worker, artifact, counter) == 10
+    res, t_ms, eng = box.try_forward(worker, artifact, counter)
+    assert res == 10
+    assert eng == "worker"
+    assert t_ms >= 0
     assert counter.read_text() == "x"
-    assert box.try_forward(worker, artifact, counter) == 10
+    res2, _, eng2 = box.try_forward(worker, artifact, counter)
+    assert res2 == 10
+    assert eng2 == "worker"
     assert counter.read_text() == "x"
 
 
@@ -77,11 +82,11 @@ def test_sandbox_disk_cache(tmp_path):
         return 5
 
     box = Sandbox(cache_dir=cache_dir)
-    assert box.try_forward(worker, artifact, counter) == 5
+    assert box.try_forward(worker, artifact, counter)[0] == 5
     assert counter.read_text() == "x"
 
     box2 = Sandbox(cache_dir=cache_dir)
-    assert box2.try_forward(worker, artifact, counter) == 5
+    assert box2.try_forward(worker, artifact, counter)[0] == 5
     assert counter.read_text() == "x"
 
 
@@ -101,7 +106,7 @@ def test_sandbox_class_key_cache(tmp_path):
             fh.write("x")
         return 7
 
-    assert box.try_forward(worker, artifact1, class_key=key) == 7
+    assert box.try_forward(worker, artifact1, class_key=key)[0] == 7
     assert artifact1.with_suffix(".cnt").read_text() == "x"
-    assert box.try_forward(worker, artifact2, class_key=key) == 7
+    assert box.try_forward(worker, artifact2, class_key=key)[0] == 7
     assert not artifact2.with_suffix(".cnt").exists()


### PR DESCRIPTION
## Summary
- track failure details including engine, op kind, ints, and timing per probe
- propagate engine and op kind from sandbox errors into the failure cache
- return timing and engine info from sandbox.try_forward and update tests

## Testing
- `pytest tests/test_failure_cache.py tests/test_sandbox.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'onnx'; RuntimeError: Numpy is not available)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6b0d7cc0832cb456b5ea3a65e976