### PR TITLE
Add sandbox output validation metrics

### DIFF
--- a/printers.py
+++ b/printers.py
@@ -64,6 +64,10 @@ def contact_trace(hyp: Dict[str, Any], validation: Dict[str, Any] | None = None,
                 metrics.append(f"{validation['time_ms']:.1f}ms")
             if "vram_mb" in validation:
                 metrics.append(f"{validation['vram_mb']:.1f}MB")
+            if "dtype_ok" in validation:
+                metrics.append("dtype" if validation["dtype_ok"] else "dtype_mismatch")
+            if "stable" in validation:
+                metrics.append("stable" if validation["stable"] else "unstable")
             if metrics:
                 trace = f"{trace} ({', '.join(metrics)})"
         return trace
@@ -184,7 +188,16 @@ def proof(log: Iterable[str], validation: Dict[str, Any] | None = None, fmt: str
 
     lines = list(log)
     if validation:
-        lines.append(f"validate {validation}")
+        metrics: List[str] = []
+        if "time_ms" in validation:
+            metrics.append(f"time={validation['time_ms']:.1f}ms")
+        if "vram_mb" in validation:
+            metrics.append(f"vram={validation['vram_mb']:.1f}MB")
+        if "dtype_ok" in validation:
+            metrics.append(f"dtype_ok={validation['dtype_ok']}")
+        if "stable" in validation:
+            metrics.append(f"stable={validation['stable']}")
+        lines.append("validate " + ", ".join(metrics))
     if fmt == "json":
         return lines
     if fmt in {"cli", "comfy"}:

--- a/sandbox.py
+++ b/sandbox.py
@@ -160,7 +160,7 @@ class Sandbox:
         raise err
 
     def validate_min_run(self, fn: Callable[..., Any], *args: Any, **kwargs: Any) -> Mapping[str, float]:
-        """Run ``fn`` once more to collect timing and VRAM metrics."""
+        """Run ``fn`` twice to collect timing and stability metrics."""
 
         q: Queue = Queue()
 
@@ -183,8 +183,53 @@ class Sandbox:
             except Exception:  # pragma: no cover - optional dependency
                 pass
 
+            def _collect_dtypes(obj: Any) -> set[str]:
+                if hasattr(obj, "dtype"):
+                    return {str(getattr(obj, "dtype"))}
+                if isinstance(obj, dict):
+                    d: set[str] = set()
+                    for v in obj.values():
+                        d.update(_collect_dtypes(v))
+                    return d
+                if isinstance(obj, (list, tuple, set)):
+                    d: set[str] = set()
+                    for v in obj:
+                        d.update(_collect_dtypes(v))
+                    return d
+                if hasattr(obj, "data"):
+                    return _collect_dtypes(getattr(obj, "data"))
+                return {type(obj).__name__}
+
+            def _has_nan_inf(obj: Any) -> bool:
+                import math
+                if isinstance(obj, dict):
+                    return any(_has_nan_inf(v) for v in obj.values())
+                if isinstance(obj, (list, tuple, set)):
+                    return any(_has_nan_inf(v) for v in obj)
+                if hasattr(obj, "data"):
+                    return _has_nan_inf(getattr(obj, "data"))
+                if isinstance(obj, float):
+                    return math.isnan(obj) or math.isinf(obj)
+                return False
+
+            def _same(a: Any, b: Any) -> bool:
+                if type(a) != type(b):
+                    return False
+                if isinstance(a, dict):
+                    if a.keys() != b.keys():
+                        return False
+                    return all(_same(a[k], b[k]) for k in a)
+                if isinstance(a, (list, tuple)):
+                    return len(a) == len(b) and all(_same(x, y) for x, y in zip(a, b))
+                if hasattr(a, "data") and hasattr(b, "data"):
+                    return _same(a.data, b.data)
+                try:
+                    return a == b
+                except Exception:
+                    return False
+
             try:
-                fn(*args, **kwargs)
+                out1 = fn(*args, **kwargs)
                 duration = (time.perf_counter() - start) * 1000.0
                 vram = 0.0
                 try:
@@ -193,7 +238,16 @@ class Sandbox:
                         vram = torch.cuda.max_memory_allocated() / (1024 * 1024)
                 except Exception:  # pragma: no cover - optional dependency
                     pass
-                q.put(("ok", {"time_ms": duration, "vram_mb": vram}))
+                try:
+                    out2 = fn(*args, **kwargs)
+                except Exception:
+                    q.put(("ok", {"time_ms": duration, "vram_mb": vram, "dtype_ok": False, "stable": False}))
+                    return
+                d1 = _collect_dtypes(out1)
+                d2 = _collect_dtypes(out2)
+                dtype_ok = d1 == d2 and len(d1) == 1
+                stable = (not _has_nan_inf(out1)) and (not _has_nan_inf(out2)) and _same(out1, out2)
+                q.put(("ok", {"time_ms": duration, "vram_mb": vram, "dtype_ok": dtype_ok, "stable": stable}))
             except Exception as e:  # pragma: no cover - error path
                 q.put(("err", repr(e)))
 

--- a/tests/test_printers.py
+++ b/tests/test_printers.py
@@ -52,3 +52,21 @@ def test_obligations_cli():
 def test_proof_ignores_comfy():
     log = ["a", "b"]
     assert printers.proof(log, fmt="comfy") == printers.proof(log, fmt="cli")
+
+
+def test_contact_trace_cli_validation_metrics():
+    hyp = {}
+    val = {"time_ms": 1.0, "vram_mb": 2.0, "dtype_ok": False, "stable": True}
+    out = printers.contact_trace(hyp, validation=val, fmt="cli")
+    assert "1.0ms" in out
+    assert "2.0MB" in out
+    assert "dtype_mismatch" in out
+    assert "stable" in out
+
+
+def test_proof_validation_metrics():
+    log = ["x"]
+    val = {"time_ms": 3.0, "vram_mb": 0.0, "dtype_ok": True, "stable": False}
+    out = printers.proof(log, validation=val)
+    assert "dtype_ok=True" in out
+    assert "stable=False" in out

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -110,3 +110,60 @@ def test_sandbox_class_key_cache(tmp_path):
     assert artifact1.with_suffix(".cnt").read_text() == "x"
     assert box.try_forward(worker, artifact2, class_key=key)[0] == 7
     assert not artifact2.with_suffix(".cnt").exists()
+
+
+def test_validate_min_run_detects_nan():
+    box = Sandbox()
+
+    def bad():
+        return float("nan")
+
+    metrics = box.validate_min_run(bad)
+    assert metrics["stable"] is False
+    assert metrics["dtype_ok"] is True
+
+
+class _DTypeFlip:
+    def __init__(self) -> None:
+        self.first = True
+
+    def __call__(self):
+        if self.first:
+            self.first = False
+            return FakeTensor(1.0, "f32")
+        return FakeTensor(1.0, "f16")
+
+
+class FakeTensor:
+    def __init__(self, data, dtype):
+        self.data = data
+        self.dtype = dtype
+
+    def __eq__(self, other):  # type: ignore[override]
+        if isinstance(other, FakeTensor):
+            return self.data == other.data
+        return NotImplemented
+
+
+def test_validate_min_run_dtype_mismatch():
+    box = Sandbox()
+    fn = _DTypeFlip()
+    metrics = box.validate_min_run(fn)
+    assert metrics["dtype_ok"] is False
+    assert metrics["stable"] is True
+
+
+def test_validate_min_run_unstable():
+    box = Sandbox()
+
+    class Counter:
+        def __init__(self) -> None:
+            self.val = 0
+
+        def __call__(self) -> int:
+            self.val += 1
+            return self.val
+
+    fn = Counter()
+    metrics = box.validate_min_run(fn)
+    assert metrics["stable"] is False


### PR DESCRIPTION
## Summary
- track dtype mismatches, NaNs/Infs and determinism by running sandbox validation twice
- expose validation metrics in contact trace and proof renderers
- test sandbox for NaN, dtype mismatch and reproducibility cases

## Testing
- `pytest tests/test_sandbox.py tests/test_printers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac239e2bc832c9615ab8888d94671