### PR TITLE
Track obligation provenance

### DIFF
--- a/printers.py
+++ b/printers.py
@@ -8,7 +8,7 @@ strings.  The functions are intentionally tiny and do not attempt to be
 complete – they merely provide placeholders for richer implementations.
 """
 
-from typing import Any, Dict, Iterable, List
+from typing import Any, Dict, Iterable, List, Mapping
 
 
 # Mapping from hypothesis keys to obligation templates.  Each template is
@@ -143,20 +143,31 @@ def contact_trace(hyp: Dict[str, Any], validation: Dict[str, Any] | None = None,
     raise ValueError(f"unknown format: {fmt}")
 
 
-def obligations(hyp: Dict[str, Any], fmt: str = "json") -> Any:
+def obligations(
+    hyp: Dict[str, Any],
+    provenance: Mapping[str, str] | None = None,
+    fmt: str = "json",
+) -> Any:
     """Derive component obligations from hypotheses.
 
-    All obligation templates are rendered, substituting known values where
-    available and ``"?"`` otherwise.
+    ``provenance`` maps hypothesis keys to the proof transcript line that
+    resolved them.  When provided the provenance is emitted alongside each
+    obligation in CLI and JSON formats.
     """
 
-
-    entries = [template.format(hyp.get(key, "?")) for key, template in _OBLIGATION_TEMPLATES.items()]
+    entries = []
+    for key, template in _OBLIGATION_TEMPLATES.items():
+        text = template.format(hyp.get(key, "?"))
+        prov = provenance.get(key) if provenance else None
+        entries.append((text, prov))
 
     if fmt == "cli":
-        return "\n".join(entries)
+        lines = [f"{text} ({prov})" if prov else text for text, prov in entries]
+        return "\n".join(lines)
     if fmt == "json":
-        return entries
+        if provenance:
+            return [{"obligation": text, "provenance": prov} for text, prov in entries]
+        return [text for text, _ in entries]
     if fmt == "comfy":
         nodes: List[Dict[str, Any]] = []
         if "TEXT_EMB_d" not in hyp:

--- a/reshell.py
+++ b/reshell.py
@@ -166,7 +166,9 @@ def run_pipeline(
         entry = header_cache[key]
         hypotheses: Dict[str, Any] = dict(entry.get("hypotheses", {}))
         validation = entry.get("validation")
-        proof_log: list[str] = [f"recognized header {key}"]
+        line = f"recognized header {key}"
+        proof_log: list[str] = [line]
+        provenance: Dict[str, str] = {k: line for k in hypotheses}
         print(f"[reshell] recognized header {key}")
     else:
         hypotheses: Dict[str, Any] = dict(meta.hints)
@@ -175,6 +177,7 @@ def run_pipeline(
 
         constraints = ConstraintSet([Equality(DimVar(k), v) for k, v in hypotheses.items()])
         hypotheses = constraints.solve()
+        provenance = {k: "seed" for k in hypotheses}
 
         # Avoid re-trying previously failed probe signatures for this header.
         planner_cls = GreedyPlanner if constraints is not None else Planner
@@ -220,13 +223,18 @@ def run_pipeline(
 
             try:
                 sandbox.try_forward(try_forward, artifact, puppet_inputs, engine=engine_name)
-                hypotheses.update(combo)
+                line = f"candidate {combo} -> ok"
+                for k, v in combo.items():
+                    if hypotheses.get(k) != v:
+                        hypotheses[k] = v
+                        provenance[k] = line
                 constraints.add(*(Equality(DimVar(k), v) for k, v in combo.items()))
-                proof_log.append(f"candidate {combo} -> ok")
+                proof_log.append(line)
                 validation = sandbox.validate_min_run(try_forward, artifact, puppet_inputs)
                 break
             except Exception as e:  # pragma: no cover - error path
                 reason = str(e)
+                line = f"candidate {combo} -> {reason}"
                 updates = parse_reason(reason)
                 # Record the failure signature with a simple error class.
                 if failure_cache:
@@ -248,9 +256,12 @@ def run_pipeline(
                 if updates:
                     constraints.add(*updates)
                     solved = constraints.solve()
-                    hypotheses.update(solved)
+                    for k, v in solved.items():
+                        if hypotheses.get(k) != v:
+                            hypotheses[k] = v
+                            provenance[k] = line
                     planner.update(solved)
-                proof_log.append(f"candidate {combo} -> {reason}")
+                proof_log.append(line)
 
         if cache_dir:
             header_cache[key] = {"hypotheses": hypotheses}
@@ -259,7 +270,7 @@ def run_pipeline(
             _save_header_cache(cache_dir, header_cache)
 
     trace_out = contact_trace(hypotheses, validation, fmt=fmt or "json")
-    oblig_out = obligations(hypotheses, fmt=fmt or "json")
+    oblig_out = obligations(hypotheses, provenance, fmt=fmt or "json")
     proof_out = proof(proof_log, validation, fmt=fmt or "cli")
 
     contact_trace_path = out_dir / "contact_trace.json"

--- a/tests/test_printers.py
+++ b/tests/test_printers.py
@@ -49,6 +49,21 @@ def test_obligations_cli():
     assert oblig_cli == "\n".join(oblig_json)
 
 
+def test_obligations_provenance():
+    hyp = {"TEXT_EMB_d": 2048, "LATENT_C": 4}
+    prov = {
+        "TEXT_EMB_d": "candidate {'TEXT_EMB_d': 2048} -> ok",
+        "LATENT_C": "candidate {'LATENT_C': 4} -> ok",
+    }
+    oblig_json = printers.obligations(hyp, provenance=prov, fmt="json")
+    assert {
+        "obligation": "TEXT_ENCODER(dim=2048)",
+        "provenance": prov["TEXT_EMB_d"],
+    } in oblig_json
+    oblig_cli = printers.obligations(hyp, provenance=prov, fmt="cli")
+    assert prov["TEXT_EMB_d"] in oblig_cli
+
+
 def test_proof_ignores_comfy():
     log = ["a", "b"]
     assert printers.proof(log, fmt="comfy") == printers.proof(log, fmt="cli")


### PR DESCRIPTION
## Summary
- propagate proof-line provenance through hypotheses and obligations
- record originating probe or constraint when run_pipeline updates hypotheses
- include provenance in obligation JSON/CLI output and test it

## Testing
- `pytest` *(fails: No module named 'numpy'; No module named 'torch')*
- `pytest tests/test_printers.py`


------
https://chatgpt.com/codex/tasks/task_e_68aac3dd70ac832c9a2591508ca82cbb