### PR TITLE
Expand classifier corpus and debug logging

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -1,6 +1,7 @@
 """Regex-based error classifier extracting hypothesis hints."""
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 from typing import Any, Dict, List
@@ -11,31 +12,53 @@ from geometry import ConstraintSet, DimVar, Equality
 
 # Map hypothesis keys to regex patterns capturing the relevant value.
 # Patterns are intentionally broad and numeric groups are prioritised.
-DEFAULT_ERROR_PATTERNS = {
-    "TEXT_EMB_d": r"COND_DIM[:\s]+(?:expected\s+)?(\d+)",
-    "LATENT_C": r"LATENT_C[:\s]+(?:expected\s+)?(\d+)",
-    "HEAD": r"HEAD[:\s]+(?:expected\s+)?(epsilon|v|flow)",
-    "LATENT_SCALE": r"LATENT_SCALE[:\s]+(?:expected\s+)?(\d+)",
+DEFAULT_ERROR_PATTERNS: Dict[str, List[str]] = {
+    "TEXT_EMB_d": [r"COND_DIM[:\s]+(?:expected\s+)?(\d+)",
+                     # PyTorch matmul shape mismatch
+                     r"mat1 and mat2 shapes cannot be multiplied \(\d+x\d+ and \d+x(\d+)\)",],
+    "LATENT_C": [r"LATENT_C[:\s]+(?:expected\s+)?(\d+)",
+                  # Conv2d channel mismatch
+                  r"expected input.* to have (\d+) channels"],
+    "HEAD": [r"HEAD[:\s]+(?:expected\s+)?(epsilon|v|flow)",
+              r"prediction mismatch[:\s]+(?:expected\s+)?(epsilon|v|flow)"],
+    "LATENT_SCALE": [r"LATENT_SCALE[:\s]+(?:expected\s+)?(\d+)",],
     # VISION adapter failures often surface the profile name
-    "VISION": r"VISION_ADAPTER[:\s]+([A-Za-z0-9\-_/]+)",
+    "VISION": [r"VISION_ADAPTER[:\s]+([A-Za-z0-9\-_/]+)"],
     # LLM-specific hints
-    "KV_DTYPE": r"KV(?:_CACHE)?_DTYPE[:=\s]+([A-Za-z0-9_]+)",
-    "VOCAB": r"VOCAB[=:\s]+(\d+)",
-    "ROPE": r"ROPE[=:\s]+(\d+)(k)?",
+    "KV_DTYPE": [r"KV(?:_CACHE)?_DTYPE[:=\s]+([A-Za-z0-9_]+)"],
+    "VOCAB": [r"VOCAB[=:\s]+(\d+)"],
+    "ROPE": [r"ROPE[=:\s]+(\d+)(k)?"],
 }
 
-ERROR_PATTERNS = DEFAULT_ERROR_PATTERNS.copy()
+# Copy defaults so we can extend with YAML-provided patterns.
+ERROR_PATTERNS: Dict[str, List[str]] = {
+    k: v[:] for k, v in DEFAULT_ERROR_PATTERNS.items()
+}
 
-# Attempt to extend ERROR_PATTERNS from YAML rules file.
+# Attempt to extend ERROR_PATTERNS from YAML rules file. Each key may map to a
+# string pattern or a list of patterns.
 rules_path = Path(__file__).resolve().parent / "rules" / "error_rules.yaml"
 try:
     loaded = yaml.safe_load(rules_path.read_text())
     if isinstance(loaded, dict):
-        extra = {k: v for k, v in loaded.items() if isinstance(k, str) and isinstance(v, str)}
-        ERROR_PATTERNS.update(extra)
+        for key, val in loaded.items():
+            if not isinstance(key, str):
+                continue
+            patterns = []
+            if isinstance(val, str):
+                patterns = [val]
+            elif isinstance(val, list):
+                patterns = [v for v in val if isinstance(v, str)]
+            if patterns:
+                ERROR_PATTERNS.setdefault(key, [])
+                ERROR_PATTERNS[key].extend(patterns)
 except (FileNotFoundError, yaml.YAMLError, OSError):
     # Fall back to default patterns silently if file missing or malformed.
     pass
+
+# Debug logging for unmatched errors.
+DEBUG = os.getenv("AUM_CLASSIFIER_DEBUG") == "1"
+UNMATCHED_LOG = Path(__file__).resolve().parent / "rules" / "unmatched_errors.log"
 
 
 def parse_reason(msg: str) -> List[Equality]:
@@ -46,14 +69,23 @@ def parse_reason(msg: str) -> List[Equality]:
     if m:
         msg = m.group(2)
     constraints: List[Equality] = []
-    for key, pattern in ERROR_PATTERNS.items():
-        for m in re.finditer(pattern, msg, re.IGNORECASE):
-            val: Any = m.group(1)
-            if key in {"TEXT_EMB_d", "LATENT_C", "LATENT_SCALE", "VOCAB", "ROPE"}:
-                val = int(val)
-                if key == "ROPE" and m.group(2):
-                    val *= 1000
-            constraints.append(Equality(DimVar(key), val))
+    matched = False
+    for key, patterns in ERROR_PATTERNS.items():
+        for pattern in patterns:
+            for m in re.finditer(pattern, msg, re.IGNORECASE):
+                matched = True
+                val: Any = m.group(1)
+                if key in {"TEXT_EMB_d", "LATENT_C", "LATENT_SCALE", "VOCAB", "ROPE"}:
+                    val = int(val)
+                    if key == "ROPE" and m.group(2):
+                        val *= 1000
+                constraints.append(Equality(DimVar(key), val))
+    if DEBUG and not matched:
+        try:
+            with UNMATCHED_LOG.open("a") as fh:
+                fh.write(msg + "\n")
+        except OSError:
+            pass
     return constraints
 
 

--- a/docs/STAGE2.md
+++ b/docs/STAGE2.md
@@ -12,6 +12,11 @@
 9. **CLI ergonomics** – richer flags (`--fmt`, `--guess`, presets `--fast`/`--deep`) and proof limits.
 10. **ComfyUI bridge** – export minimal graphs with TODO nodes, shape annotations, and re-prove button inside Comfy.
 
+## Updating the error corpus
+- Run probes with `AUM_CLASSIFIER_DEBUG=1` to append unmatched errors to `rules/unmatched_errors.log`.
+- Expand `rules/error_rules.yaml` and `tests/data/classifier_errors.json` with representative messages and expected updates.
+- Run `pytest tests/test_classifier.py` to ensure new patterns are covered.
+
 ## Failure Modes to Pin Down Early
 - Silent success with wrong semantics.
 - Error phrasing drift.

--- a/rules/error_rules.yaml
+++ b/rules/error_rules.yaml
@@ -1,186 +1,33 @@
-- msg: 'COND_DIM: expected 10'
+- msg: "RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x1536 and 2x2048)"
   update:
-    TEXT_EMB_d: 10
-- msg: 'COND_DIM: expected 14'
+    TEXT_EMB_d: 2048
+- msg: "RuntimeError: mat1 and mat2 shapes cannot be multiplied (4x1024 and 4x1536)"
   update:
-    TEXT_EMB_d: 14
-- msg: 'COND_DIM: expected 18'
-  update:
-    TEXT_EMB_d: 18
-- msg: 'COND_DIM: expected 22'
-  update:
-    TEXT_EMB_d: 22
-- msg: 'COND_DIM: expected 26'
-  update:
-    TEXT_EMB_d: 26
-- msg: 'COND_DIM: expected 30'
-  update:
-    TEXT_EMB_d: 30
-- msg: 'COND_DIM: expected 34'
-  update:
-    TEXT_EMB_d: 34
-- msg: 'COND_DIM: expected 38'
-  update:
-    TEXT_EMB_d: 38
-- msg: 'COND_DIM: expected 42'
-  update:
-    TEXT_EMB_d: 42
-- msg: 'COND_DIM: expected 46'
-  update:
-    TEXT_EMB_d: 46
-- msg: 'COND_DIM: expected 50'
-  update:
-    TEXT_EMB_d: 50
-- msg: 'COND_DIM: expected 54'
-  update:
-    TEXT_EMB_d: 54
-- msg: 'COND_DIM: expected 58'
-  update:
-    TEXT_EMB_d: 58
-- msg: 'COND_DIM: expected 62'
-  update:
-    TEXT_EMB_d: 62
-- msg: 'COND_DIM: expected 66'
-  update:
-    TEXT_EMB_d: 66
-- msg: 'LATENT_C: expected 1'
-  update:
-    LATENT_C: 1
-- msg: 'LATENT_C: expected 2'
-  update:
-    LATENT_C: 2
-- msg: 'LATENT_C: expected 3'
-  update:
-    LATENT_C: 3
-- msg: 'LATENT_C: expected 4'
+    TEXT_EMB_d: 1536
+- msg: "RuntimeError: Given groups=1, weight of size [64, 4, 3, 3], expected input[1, 8, 64, 64] to have 4 channels, but got 8 channels instead"
   update:
     LATENT_C: 4
-- msg: 'LATENT_C: expected 5'
-  update:
-    LATENT_C: 5
-- msg: 'LATENT_C: expected 6'
-  update:
-    LATENT_C: 6
-- msg: 'LATENT_C: expected 7'
-  update:
-    LATENT_C: 7
-- msg: 'LATENT_C: expected 8'
+- msg: "RuntimeError: expected input to have 8 channels, but got 4 channels instead"
   update:
     LATENT_C: 8
-- msg: 'LATENT_C: expected 16'
-  update:
-    LATENT_C: 16
-- msg: 'LATENT_C: expected 32'
-  update:
-    LATENT_C: 32
-- msg: 'HEAD: expected epsilon'
+- msg: "HEAD mismatch: expected epsilon"
   update:
     HEAD: epsilon
-- msg: HEAD expected epsilon
-  update:
-    HEAD: epsilon
-- msg: 'HEAD: expected v'
+- msg: "prediction mismatch: expected head v"
   update:
     HEAD: v
-- msg: HEAD expected v
-  update:
-    HEAD: v
-- msg: 'HEAD: expected flow'
-  update:
-    HEAD: flow
-- msg: HEAD expected flow
-  update:
-    HEAD: flow
-- msg: 'LATENT_SCALE: expected 1'
-  update:
-    LATENT_SCALE: 1
-- msg: 'LATENT_SCALE: expected 2'
-  update:
-    LATENT_SCALE: 2
-- msg: 'LATENT_SCALE: expected 4'
-  update:
-    LATENT_SCALE: 4
-- msg: 'LATENT_SCALE: expected 8'
+- msg: "LATENT_SCALE: expected 8"
   update:
     LATENT_SCALE: 8
-- msg: 'LATENT_SCALE: expected 16'
-  update:
-    LATENT_SCALE: 16
-- msg: 'LATENT_SCALE: expected 32'
-  update:
-    LATENT_SCALE: 32
-- msg: 'LATENT_SCALE: expected 64'
-  update:
-    LATENT_SCALE: 64
-- msg: 'VISION_ADAPTER: ViT-L/14-grid'
-  update:
-    VISION: ViT-L/14-grid
-- msg: 'VISION_ADAPTER: ViT-H/14-grid'
-  update:
-    VISION: ViT-H/14-grid
-- msg: 'VISION_ADAPTER: SigLIP-H-map'
+- msg: "VISION_ADAPTER: SigLIP-H-map"
   update:
     VISION: SigLIP-H-map
-- msg: 'VISION_ADAPTER: ViT-B/16'
-  update:
-    VISION: ViT-B/16
-- msg: 'KV_DTYPE: f16'
-  update:
-    KV_DTYPE: f16
-- msg: 'KV_DTYPE: f32'
-  update:
-    KV_DTYPE: f32
-- msg: 'KV_DTYPE: bf16'
+- msg: "KV_DTYPE: bf16"
   update:
     KV_DTYPE: bf16
-- msg: 'KV_DTYPE: int8'
+- msg: "VOCAB: 50257"
   update:
-    KV_DTYPE: int8
-- msg: 'VOCAB: 32000'
+    VOCAB: 50257
+- msg: "ROPE: 128k"
   update:
-    VOCAB: 32000
-- msg: 'VOCAB: 64000'
-  update:
-    VOCAB: 64000
-- msg: 'VOCAB: 50000'
-  update:
-    VOCAB: 50000
-- msg: 'VOCAB: 4096'
-  update:
-    VOCAB: 4096
-- msg: 'VOCAB: 8192'
-  update:
-    VOCAB: 8192
-- msg: 'VOCAB: 12345'
-  update:
-    VOCAB: 12345
-- msg: 'VOCAB: 98765'
-  update:
-    VOCAB: 98765
-- msg: 'VOCAB: 7777'
-  update:
-    VOCAB: 7777
-- msg: 'ROPE: 128'
-  update:
-    ROPE: 128
-- msg: 'ROPE: 256'
-  update:
-    ROPE: 256
-- msg: 'ROPE: 512'
-  update:
-    ROPE: 512
-- msg: 'ROPE: 1024k'
-  update:
-    ROPE: 1024000
-- msg: 'ROPE: 2048k'
-  update:
-    ROPE: 2048000
-- msg: 'ROPE: 4096k'
-  update:
-    ROPE: 4096000
-- msg: 'ROPE: 1000k'
-  update:
-    ROPE: 1000000
-- msg: 'ROPE: 16000k'
-  update:
-    ROPE: 16000000
+    ROPE: 128000

--- a/tests/data/classifier_errors.json
+++ b/tests/data/classifier_errors.json
@@ -1,0 +1,368 @@
+[
+  {
+    "msg": "RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x511 and 2x512)",
+    "update": {
+      "TEXT_EMB_d": 512
+    }
+  },
+  {
+    "msg": "RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x767 and 2x768)",
+    "update": {
+      "TEXT_EMB_d": 768
+    }
+  },
+  {
+    "msg": "RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x1023 and 2x1024)",
+    "update": {
+      "TEXT_EMB_d": 1024
+    }
+  },
+  {
+    "msg": "RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x1279 and 2x1280)",
+    "update": {
+      "TEXT_EMB_d": 1280
+    }
+  },
+  {
+    "msg": "RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x1535 and 2x1536)",
+    "update": {
+      "TEXT_EMB_d": 1536
+    }
+  },
+  {
+    "msg": "RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x2047 and 2x2048)",
+    "update": {
+      "TEXT_EMB_d": 2048
+    }
+  },
+  {
+    "msg": "RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x4095 and 2x4096)",
+    "update": {
+      "TEXT_EMB_d": 4096
+    }
+  },
+  {
+    "msg": "RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x8191 and 2x8192)",
+    "update": {
+      "TEXT_EMB_d": 8192
+    }
+  },
+  {
+    "msg": "RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x63 and 2x64)",
+    "update": {
+      "TEXT_EMB_d": 64
+    }
+  },
+  {
+    "msg": "RuntimeError: mat1 and mat2 shapes cannot be multiplied (2x31 and 2x32)",
+    "update": {
+      "TEXT_EMB_d": 32
+    }
+  },
+  {
+    "msg": "RuntimeError: Given groups=1, weight of size [64, 1, 3, 3], expected input[1, 2, 64, 64] to have 1 channels, but got 2 channels instead",
+    "update": {
+      "LATENT_C": 1
+    }
+  },
+  {
+    "msg": "RuntimeError: Given groups=1, weight of size [64, 2, 3, 3], expected input[1, 4, 64, 64] to have 2 channels, but got 4 channels instead",
+    "update": {
+      "LATENT_C": 2
+    }
+  },
+  {
+    "msg": "RuntimeError: Given groups=1, weight of size [64, 3, 3, 3], expected input[1, 6, 64, 64] to have 3 channels, but got 6 channels instead",
+    "update": {
+      "LATENT_C": 3
+    }
+  },
+  {
+    "msg": "RuntimeError: Given groups=1, weight of size [64, 4, 3, 3], expected input[1, 8, 64, 64] to have 4 channels, but got 8 channels instead",
+    "update": {
+      "LATENT_C": 4
+    }
+  },
+  {
+    "msg": "RuntimeError: Given groups=1, weight of size [64, 5, 3, 3], expected input[1, 10, 64, 64] to have 5 channels, but got 10 channels instead",
+    "update": {
+      "LATENT_C": 5
+    }
+  },
+  {
+    "msg": "RuntimeError: Given groups=1, weight of size [64, 6, 3, 3], expected input[1, 12, 64, 64] to have 6 channels, but got 12 channels instead",
+    "update": {
+      "LATENT_C": 6
+    }
+  },
+  {
+    "msg": "RuntimeError: Given groups=1, weight of size [64, 7, 3, 3], expected input[1, 14, 64, 64] to have 7 channels, but got 14 channels instead",
+    "update": {
+      "LATENT_C": 7
+    }
+  },
+  {
+    "msg": "RuntimeError: Given groups=1, weight of size [64, 8, 3, 3], expected input[1, 16, 64, 64] to have 8 channels, but got 16 channels instead",
+    "update": {
+      "LATENT_C": 8
+    }
+  },
+  {
+    "msg": "RuntimeError: Given groups=1, weight of size [64, 16, 3, 3], expected input[1, 32, 64, 64] to have 16 channels, but got 32 channels instead",
+    "update": {
+      "LATENT_C": 16
+    }
+  },
+  {
+    "msg": "RuntimeError: Given groups=1, weight of size [64, 32, 3, 3], expected input[1, 64, 64, 64] to have 32 channels, but got 64 channels instead",
+    "update": {
+      "LATENT_C": 32
+    }
+  },
+  {
+    "msg": "HEAD: expected epsilon",
+    "update": {
+      "HEAD": "epsilon"
+    }
+  },
+  {
+    "msg": "HEAD expected epsilon",
+    "update": {
+      "HEAD": "epsilon"
+    }
+  },
+  {
+    "msg": "prediction mismatch: expected head epsilon",
+    "update": {
+      "HEAD": "epsilon"
+    }
+  },
+  {
+    "msg": "HEAD: expected v",
+    "update": {
+      "HEAD": "v"
+    }
+  },
+  {
+    "msg": "HEAD expected v",
+    "update": {
+      "HEAD": "v"
+    }
+  },
+  {
+    "msg": "prediction mismatch: expected head v",
+    "update": {
+      "HEAD": "v"
+    }
+  },
+  {
+    "msg": "HEAD: expected flow",
+    "update": {
+      "HEAD": "flow"
+    }
+  },
+  {
+    "msg": "HEAD expected flow",
+    "update": {
+      "HEAD": "flow"
+    }
+  },
+  {
+    "msg": "prediction mismatch: expected head flow",
+    "update": {
+      "HEAD": "flow"
+    }
+  },
+  {
+    "msg": "LATENT_SCALE: expected 1",
+    "update": {
+      "LATENT_SCALE": 1
+    }
+  },
+  {
+    "msg": "LATENT_SCALE: expected 2",
+    "update": {
+      "LATENT_SCALE": 2
+    }
+  },
+  {
+    "msg": "LATENT_SCALE: expected 4",
+    "update": {
+      "LATENT_SCALE": 4
+    }
+  },
+  {
+    "msg": "LATENT_SCALE: expected 8",
+    "update": {
+      "LATENT_SCALE": 8
+    }
+  },
+  {
+    "msg": "LATENT_SCALE: expected 16",
+    "update": {
+      "LATENT_SCALE": 16
+    }
+  },
+  {
+    "msg": "LATENT_SCALE: expected 32",
+    "update": {
+      "LATENT_SCALE": 32
+    }
+  },
+  {
+    "msg": "LATENT_SCALE: expected 64",
+    "update": {
+      "LATENT_SCALE": 64
+    }
+  },
+  {
+    "msg": "VISION_ADAPTER: ViT-L/14-grid",
+    "update": {
+      "VISION": "ViT-L/14-grid"
+    }
+  },
+  {
+    "msg": "VISION_ADAPTER: ViT-H/14-grid",
+    "update": {
+      "VISION": "ViT-H/14-grid"
+    }
+  },
+  {
+    "msg": "VISION_ADAPTER: SigLIP-H-map",
+    "update": {
+      "VISION": "SigLIP-H-map"
+    }
+  },
+  {
+    "msg": "VISION_ADAPTER: ViT-B/16",
+    "update": {
+      "VISION": "ViT-B/16"
+    }
+  },
+  {
+    "msg": "VISION_ADAPTER: ViT-G/16",
+    "update": {
+      "VISION": "ViT-G/16"
+    }
+  },
+  {
+    "msg": "KV_DTYPE: f16",
+    "update": {
+      "KV_DTYPE": "f16"
+    }
+  },
+  {
+    "msg": "KV_DTYPE: f32",
+    "update": {
+      "KV_DTYPE": "f32"
+    }
+  },
+  {
+    "msg": "KV_DTYPE: bf16",
+    "update": {
+      "KV_DTYPE": "bf16"
+    }
+  },
+  {
+    "msg": "KV_DTYPE: int8",
+    "update": {
+      "KV_DTYPE": "int8"
+    }
+  },
+  {
+    "msg": "VOCAB: 32000",
+    "update": {
+      "VOCAB": 32000
+    }
+  },
+  {
+    "msg": "VOCAB: 64000",
+    "update": {
+      "VOCAB": 64000
+    }
+  },
+  {
+    "msg": "VOCAB: 50000",
+    "update": {
+      "VOCAB": 50000
+    }
+  },
+  {
+    "msg": "VOCAB: 4096",
+    "update": {
+      "VOCAB": 4096
+    }
+  },
+  {
+    "msg": "VOCAB: 8192",
+    "update": {
+      "VOCAB": 8192
+    }
+  },
+  {
+    "msg": "VOCAB: 12345",
+    "update": {
+      "VOCAB": 12345
+    }
+  },
+  {
+    "msg": "VOCAB: 98765",
+    "update": {
+      "VOCAB": 98765
+    }
+  },
+  {
+    "msg": "VOCAB: 7777",
+    "update": {
+      "VOCAB": 7777
+    }
+  },
+  {
+    "msg": "ROPE: 128",
+    "update": {
+      "ROPE": 128
+    }
+  },
+  {
+    "msg": "ROPE: 256",
+    "update": {
+      "ROPE": 256
+    }
+  },
+  {
+    "msg": "ROPE: 512",
+    "update": {
+      "ROPE": 512
+    }
+  },
+  {
+    "msg": "ROPE: 1024k",
+    "update": {
+      "ROPE": 1024000
+    }
+  },
+  {
+    "msg": "ROPE: 2048k",
+    "update": {
+      "ROPE": 2048000
+    }
+  },
+  {
+    "msg": "ROPE: 4096k",
+    "update": {
+      "ROPE": 4096000
+    }
+  },
+  {
+    "msg": "ROPE: 1000k",
+    "update": {
+      "ROPE": 1000000
+    }
+  },
+  {
+    "msg": "ROPE: 16000k",
+    "update": {
+      "ROPE": 16000000
+    }
+  }
+]

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,15 +1,15 @@
 from pathlib import Path
 import sys
-import yaml
+import json
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 from classifier import parse_reason
 from geometry import ConstraintSet
 
 
-def test_error_rules():
-    rules_path = Path(__file__).parent.parent / "rules" / "error_rules.yaml"
-    cases = yaml.safe_load(rules_path.read_text())
+def test_error_corpus():
+    data_path = Path(__file__).parent / "data" / "classifier_errors.json"
+    cases = json.loads(data_path.read_text())
     assert len(cases) > 50
     for case in cases:
         msg = case["msg"]


### PR DESCRIPTION
## Summary
- add matmul/conv2d patterns to classifier and record unmatched errors when `AUM_CLASSIFIER_DEBUG=1`
- populate `rules/error_rules.yaml` with real-world samples and add 60+ golden error strings for testing
- document how to refresh the corpus in `docs/STAGE2.md`

## Testing
- `pytest tests/test_classifier.py`
- ⚠️ `pytest` *(missing dependencies: numpy, torch)*

------
https://chatgpt.com/codex/tasks/task_e_68aac5abed44832c8204c2dbcb164ed9