### PR TITLE
Capture oracle hints and expose via classifier

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -15,10 +15,12 @@ from geometry import ConstraintSet, DimVar, Equality
 DEFAULT_ERROR_PATTERNS: Dict[str, List[str]] = {
     "TEXT_EMB_d": [r"COND_DIM[:\s]+(?:expected\s+)?(\d+)",
                      # PyTorch matmul shape mismatch
-                     r"mat1 and mat2 shapes cannot be multiplied \(\d+x\d+ and \d+x(\d+)\)",],
+                     r"mat1 and mat2 shapes cannot be multiplied \(\d+x\d+ and \d+x(\d+)\)",
+                     r"TEXT_EMB_d[=:\s]+(\d+)",],
     "LATENT_C": [r"LATENT_C[:\s]+(?:expected\s+)?(\d+)",
                   # Conv2d channel mismatch
-                  r"expected input.* to have (\d+) channels"],
+                  r"expected input.* to have (\d+) channels",
+                  r"LATENT_C[=:\s]+(\d+)"],
     "HEAD": [r"HEAD[:\s]+(?:expected\s+)?(epsilon|v|flow)",
               r"prediction mismatch[:\s]+(?:expected\s+)?(epsilon|v|flow)"],
     "LATENT_SCALE": [r"LATENT_SCALE[:\s]+(?:expected\s+)?(\d+)",],
@@ -28,6 +30,7 @@ DEFAULT_ERROR_PATTERNS: Dict[str, List[str]] = {
     "KV_DTYPE": [r"KV(?:_CACHE)?_DTYPE[:=\s]+([A-Za-z0-9_]+)"],
     "VOCAB": [r"VOCAB[=:\s]+(\d+)"],
     "ROPE": [r"ROPE[=:\s]+(\d+)(k)?"],
+    "LAYOUT": [r"LAYOUT[=:\s]+([A-Za-z0-9_\-]+)"],
 }
 
 # Copy defaults so we can extend with YAML-provided patterns.

--- a/oracles/onnx.py
+++ b/oracles/onnx.py
@@ -10,19 +10,28 @@ def _engine_forward(artifact: Path, inputs: Dict[str, Any]) -> str:
     import re
 
     sess = ort.InferenceSession(str(artifact))
-    input_name = sess.get_inputs()[0].name
-    expected = sess.get_inputs()[0].shape[-1]
+    inputs_info = sess.get_inputs()
+    input_name = inputs_info[0].name
+    shape = inputs_info[0].shape
+    expected = shape[-1] if shape and isinstance(shape[-1], int) else None
+    hints = []
+    if expected is not None:
+        hints.append(f"TEXT_EMB_d={expected}")
     data = next(iter(inputs.values()))
     if hasattr(data, "numpy"):
         data = data.numpy()
-    if data.shape[-1] != expected:
+    if expected is not None and data.shape[-1] != expected:
         raise RuntimeError(f"COND_DIM: expected {expected}")
     try:
         sess.run(None, {input_name: np.asarray(data)})
     except Exception as e:  # pragma: no cover - depends on runtime errors
         msg = str(e)
         ints = re.findall(r"\d+", msg)
+        parts = []
         if ints:
-            raise RuntimeError("ONNX_FAIL: " + " ".join(ints)) from e
+            parts.extend(ints)
+        parts.extend(hints)
+        if parts:
+            raise RuntimeError("ONNX_FAIL: " + " ".join(parts)) from e
         raise
     return "ok"

--- a/oracles/xformers.py
+++ b/oracles/xformers.py
@@ -17,10 +17,20 @@ def _engine_forward() -> str:
     import re
 
     try:
-        xops.memory_efficient_attention(q, k, v)
+        xops.memory_efficient_attention(q, k, v, mem_efficient=True)
     except Exception as e:  # pragma: no cover - layout/type mismatches
-        ints = re.findall(r"\d+", str(e))
+        msg = str(e)
+        ints = re.findall(r"\d+", msg)
+        layout = None
+        m = re.search(r"layout[=:\s]+([A-Za-z0-9_\-]+)", msg)
+        if m:
+            layout = m.group(1)
+        parts = []
         if ints:
-            raise RuntimeError("XFORMERS_FAIL: " + " ".join(ints)) from e
+            parts.extend(ints)
+        if layout:
+            parts.append(f"LAYOUT={layout}")
+        if parts:
+            raise RuntimeError("XFORMERS_FAIL: " + " ".join(parts)) from e
         raise
     return "ok"

--- a/tests/test_oracles.py
+++ b/tests/test_oracles.py
@@ -1,5 +1,14 @@
 from pathlib import Path
+import types
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import numpy as np
 import oracles
+import oracles.onnx as onnx_oracle
+import oracles.xformers as xformers_oracle
+import pytest
+from classifier import constraints_from_error
 
 
 def test_try_forward_uses_patched_torch(monkeypatch):
@@ -16,3 +25,51 @@ def test_try_forward_uses_patched_torch(monkeypatch):
 
     assert called.get("flag") is True
     assert result == "patched"
+
+
+def test_onnx_static_shape_hint(monkeypatch, tmp_path):
+    class DummyInput:
+        name = "x"
+        shape = [1, 3]
+
+    class DummySession:
+        def __init__(self, path):
+            pass
+
+        def get_inputs(self):
+            return [DummyInput()]
+
+        def run(self, *_a, **_k):
+            raise RuntimeError("runtime 7 8")
+
+    dummy_ort = types.SimpleNamespace(InferenceSession=DummySession)
+    monkeypatch.setitem(sys.modules, "onnxruntime", dummy_ort)
+
+    artifact = tmp_path / "m.onnx"
+    artifact.write_bytes(b"onnx")
+    with pytest.raises(RuntimeError) as exc:
+        onnx_oracle._engine_forward(artifact, {"x": np.zeros((1, 3), dtype=np.float32)})
+    solved = constraints_from_error(str(exc.value)).solve()
+    assert solved == {"TEXT_EMB_d": 3}
+
+
+def test_xformers_layout_hint(monkeypatch):
+    class DummyTorch:
+        float16 = "f16"
+
+        @staticmethod
+        def randn(*a, **k):
+            return object()
+
+    def fake_mea(q, k, v, mem_efficient=True):
+        raise RuntimeError("layout=sbpck")
+
+    xops = types.SimpleNamespace(memory_efficient_attention=fake_mea)
+    monkeypatch.setitem(sys.modules, "torch", DummyTorch)
+    monkeypatch.setitem(sys.modules, "xformers", types.SimpleNamespace(ops=xops))
+    monkeypatch.setitem(sys.modules, "xformers.ops", xops)
+
+    with pytest.raises(RuntimeError) as exc:
+        xformers_oracle._engine_forward()
+    solved = constraints_from_error(str(exc.value)).solve()
+    assert solved == {"LAYOUT": "sbpck"}


### PR DESCRIPTION
## Summary
- surface static ONNX input shapes before inference and attach them to failure messages
- probe xFormers with mem_efficient=True and raise layout hints on failure
- expand classifier to parse explicit TEXT_EMB_d, LATENT_C, and layout hints; add regression tests

## Testing
- `pytest tests/test_oracles.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_68aac7ce48c8832cad87df650efb27d9